### PR TITLE
Explaining what this repo is about

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -63,7 +63,7 @@ $ sudo apt-get install libgtk2.0-dev libasound2-dev libavformat-dev libjack-jack
    For example, in the **git-bash** run:
 
     ```
-    $ git clone https://github.com/audacity/audacity/
+    $ git clone https://github.com/cookiengineer/audacity/
     ```
 
 2. Open CMake GUI. 
@@ -91,7 +91,7 @@ Generally, steps 1-5 are only needed the first-time you configure. Then, after y
 1. Clone Audacity from the Audacity GitHub project. 
   
     ```
-    $ git clone https://github.com/audacity/audacity/
+    $ git clone https://github.com/cookiengineer/audacity/
     ```
 
 2. Configure Audacity using CMake:
@@ -121,7 +121,7 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
 1. Clone Audacity from the Audacity GitHub project. 
   
     ```
-    $ git clone https://github.com/audacity/audacity/
+    $ git clone https://github.com/cookiengineer/audacity/
     ```
 
 2. Configure Audacity using CMake:

--- a/README.md
+++ b/README.md
@@ -14,11 +14,19 @@
 - **Accessibility** for VI users.
 - **Analysis and visualization** tools to analyze audio, or other signal data.
 
+## This repository
+
+This repository is a fork of Audacity that tries to revert all the sketchy changes made to the software in recent months, mostly related to data collection. You can find more informations on what happened in these Github issues on the original Audacity repository :
+
+- [**Privacy policy that doesn't respect the GPL**](https://github.com/audacity/audacity/issues/1213)
+- [**Discussion on the Contributer's License Agreement (CLA), goes against the GPL**](https://github.com/audacity/audacity/discussions/932)
+- [**Pull request trying to implement telemetry using Google's services (did not pass)**](https://github.com/audacity/audacity/pull/835)
+
 ## Getting Started
 
-For end users, the latest Windows and macOS release version of Audacity is available from the [Audacity website](https://www.audacityteam.org/download/).
-Help with using Audacity is available from the [Audacity Forum](https://forum.audacityteam.org/).
+For end users, the latest Windows and macOS release of the *original* version of Audacity is available from the *original* [Audacity website](https://www.audacityteam.org/download/). Note that this is the unmodified version which still contains some sketchy code.
+Help with using Audacity is available from the original [Audacity Forum](https://forum.audacityteam.org/).
 
 Build instructions are available [here](BUILDING.md).
 
-More information for developers is available from the [Audacity Wiki](https://wiki.audacityteam.org/wiki/For_Developers).
+More information for developers is available from the original [Audacity Wiki](https://wiki.audacityteam.org/wiki/For_Developers).


### PR DESCRIPTION
This PR tries to clarify that this isn't the original audacity, and explains that links to the Audacity website will make you download the Audacity team's version of the software, not the one developed here.

I only edited the README and build instructions, there are probably other things to edit to go the same way, but I think this is a good start, and clears up what this is about to anyone landing on the repo.

It'd be great if there were pre-built binaries of this fork that we could link to in the README, so that we could remove all links to the original version to avoid confusion.