### PR TITLE
Fix compilation issues

### DIFF
--- a/src/SentryHelper.h
+++ b/src/SentryHelper.h
@@ -1,0 +1,1 @@
+#define ADD_EXCEPTION_CONTEXT(name, value)

--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -529,8 +529,7 @@ BaseItemSharedPtr HelpMenu()
                AudioIONotBusyFlag() ),
       #endif
             Command( wxT("Log"), XXO("Show &Log..."), FN(OnShowLog),
-               AlwaysEnabledFlag ),
-      #endif
+               AlwaysEnabledFlag )
 
       #ifdef IS_ALPHA
             ,


### PR DESCRIPTION
The code as it is doesn't compile.
There are a few problems:
- `SentryHelper.h` is required for `ADD_EXCEPTION_CONTEXT` macros.
- `HelpMenus.cpp` has a few syntax problems.