### PR TITLE
Compile Fix for MSVC

### DIFF
--- a/src/HelpText.cpp
+++ b/src/HelpText.cpp
@@ -229,7 +229,6 @@ static wxString HelpTextBuiltIn( const wxString & Key )
 "We strongly recommend that you use our latest stable released version, which has full documentation and support.<br><br>")
          << XO(
 "You can help us get Audacity ready for release by joining our [[https://www.audacityteam.org/community/|community]].<hr><br><br>")
-#endif
 
 // DA: Support methods text.
 #ifdef EXPERIMENTAL_DA


### PR DESCRIPTION
Fixes a dangling `#endif` to allow the project to be compiled in MSVC.

Feel free to close this PR, just wanted to notify that the project can't be compiled without this change.