### PR TITLE
Fix typos in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This fork of **audacity** is an easy-to-use, cross-platform multi-track audio ed
 - **Recording** from audio devices (real or virtual)
 - **Export / Import** a wide range of audio formats (extendible with FFmpeg)
 - **High quality** including up to 32-bit float audio support
-- **Plug-ins** Plug-in support for VST, LV2, and AU plugins
+- **Plug-ins** providing support for VST, LV2, and AU plugins
 - **Scripting** in the built-in scripting language Nyquist, or in Python, Perl and other languages with named pipes
 - **Editing** arbitrary sampling and multi-track timeline
 - **Accessibility** including editing via keyboard, screen reader support and narration support
@@ -17,7 +17,7 @@ This fork of **audacity** is an easy-to-use, cross-platform multi-track audio ed
 
 ## Why did this project fork audacity/audacity?
 
-You can find more informations on what happened in these Github issues on the original audacity repository :
+You can find more information on the causes of the fork here:
 
 - [**Privacy policy which may violate the original project's GPL license**](https://github.com/audacity/audacity/issues/1213)
 - [**Contributer's License Agreement (CLA) which may violate the same GPL license**](https://github.com/audacity/audacity/discussions/932)
@@ -26,8 +26,8 @@ You can find more informations on what happened in these Github issues on the or
 ## Pre-fork Access
 
 The latest Windows and macOS release of the pre-fork version of this repository may be available from the [Audacity website](https://www.audacityteam.org/download/). 
-Additionally, they one may find help and/or support for the pre-fork releases at the [Audacity Forum](https://forum.audacityteam.org/).
-Developers may find support for the pre-fork releases available at the [Audacity Wiki](https://wiki.audacityteam.org/wiki/For_Developers).
+Additionally, one may find help and/or support for the pre-fork releases at the [Audacity Forum](https://forum.audacityteam.org/).
+Developers may find information for the pre-fork releases available at the [Audacity Wiki](https://wiki.audacityteam.org/wiki/For_Developers).
 
 
 ## Getting Started


### PR DESCRIPTION
Fix a typo - an erroneous "they".
Modify list formatting to be consistently capitalized.
Modify word choice for developer pre-fork hyperlink anchor.
Fix typo involving the use of "informations" when it should've been singular.
