### PR TITLE
Removed code signing and notarization from Windows/macOS builds

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -15,10 +15,6 @@ jobs:
     env:
       AUDACITY_CMAKE_GENERATOR: ${{ matrix.config.generator }}
       AUDACITY_ARCH_LABEL: ${{ matrix.config.arch }}
-      # Windows codesigning
-      # This variables will be used by all the steps
-      WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
-      WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
       # Conan home location to be used for cache action
       CONAN_USER_HOME: "${{ github.workspace }}/conan-home/"
       CONAN_USER_HOME_SHORT: "${{ github.workspace }}/conan-home/short"
@@ -60,13 +56,6 @@ jobs:
       run: |
         source "scripts/ci/environment.sh"
     
-    - name: Install Apple codesigning certificates
-      uses: apple-actions/import-codesign-certs@v1
-      if: startswith( matrix.config.os, 'macos' ) && github.event_name == 'push' && github.repository_owner == 'audacity'
-      with: 
-        p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
-        p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-
     - name: Cache for .conan
       id: cache-conan
       uses: actions/cache@v2
@@ -79,11 +68,6 @@ jobs:
           host-${{ matrix.config.name }}-
 
     - name: Configure
-      env:
-        # Apple code signing
-        APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
-        APPLE_NOTARIZATION_USER_NAME: ${{ secrets.APPLE_NOTARIZATION_USER_NAME }}
-        APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
       run: |
         exec bash "scripts/ci/configure.sh"
 


### PR DESCRIPTION
The scripts in the `scripts` directory are flexible, in the sense that they
were also developed with scenarios, such as not being supplied any credentials
whatsoever. This means that we can just remove the environment variables
concerning code, and it should just work.

These changes have not been tested thoroughly yet, but are an improvement
given our situation. We hope to bring these back eventually, but they cost
money.

- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
