### PR TITLE
Fix relative dir in build instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -97,7 +97,7 @@ Generally, steps 1-5 are only needed the first-time you configure. Then, after y
 2. Configure Audacity using CMake:
    ```
    $ mkdir build && cd build
-   $ cmake -GXcode -T buildsystem=1 ../audacity
+   $ cmake -GXcode -T buildsystem=1 ..
    ```
 
 3. Open Audacity XCode project:
@@ -113,7 +113,7 @@ Alternatively, you can use **CLion**. If you chose to do so, open the directory 
 At the moment we only support **x86_64** builds. It is possible to build using AppleSilicon hardware but **mad** and **id3tag** should be disabled:
 
 ```
-cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=off ../audacity
+cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=off ..
 ```
 
 ## Linux & Other OS
@@ -127,7 +127,7 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
 2. Configure Audacity using CMake:
    ```
    $ mkdir build && cd build
-   $ cmake -G "Unix Makefiles" -Daudacity_use_ffmpeg=loaded ../audacity
+   $ cmake -G "Unix Makefiles" -Daudacity_use_ffmpeg=loaded ..
    ```
    By default, Debug build will be configured. To change that, pass `-DCMAKE_BUILD_TYPE=Release` to CMake.
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -96,7 +96,7 @@ Generally, steps 1-5 are only needed the first-time you configure. Then, after y
 
 2. Configure Tenacity using CMake:
    ```
-   $ mkdir build && cd build
+   $ cd tenacity && mkdir build && cd build
    $ cmake -GXcode -T buildsystem=1 ..
    ```
 
@@ -126,7 +126,7 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
 
 2. Configure Tenacity using CMake:
    ```
-   $ mkdir build && cd build
+   $ cd tenacity && mkdir build && cd build
    $ cmake -G "Unix Makefiles" -Daudacity_use_ffmpeg=loaded ..
    ```
    By default, Debug build will be configured. To change that, pass `-DCMAKE_BUILD_TYPE=Release` to CMake.


### PR DESCRIPTION
Since we `cd` to build dir, the `../audacity` cmake root dir path doesnt make sense.
Maybe it is intended to not create the build dir inside the code repo? In that case s/audacity/tenacity/ change is needed.

I didn't open a ticket about this, since it is not clear if the `build` dir should be created inside the tenacity source code folder or not.
It is often the case for building things with cmake that we create the build dir in the repo. If we create that outside, it can can conflict with any other project we have in parallel in the same directory that is already built (which can be an different copy of audacity for example), since all of them will be using the same ../build dir.

- [x] The code in this pull request is licensed under "GPLv2 or any later version"
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
