### PR TITLE
AboutDialog: Fix build commit link

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -69,7 +69,7 @@ hold information about one contributor to Audacity.
 #endif
 
 #ifdef REV_LONG
-#define REV_IDENT wxString( "[[https://github.com/audacity/audacity/commit/" )+ REV_LONG + "|" + wxString( REV_LONG ).Left(6) + "]] of " +  REV_TIME 
+#define REV_IDENT wxString( "[[https://github.com/tenacityteam/tenacity/commit/" )+ REV_LONG + "|" + wxString( REV_LONG ).Left(6) + "]] of " +  REV_TIME 
 #else
 #define REV_IDENT (XO("No revision identifier was provided").Translation())
 #endif


### PR DESCRIPTION
If you're in the AboutDialog and want to click on the build commit, you are now redirected to tenacity's commits instead of the upstream's one.

- [x] The code in this pull request is licensed under "GPLv2 or any later version"
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
