### PR TITLE
Fix CI: Use Readme.md instead of Readme.txt due to deletion of old file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1360,7 +1360,7 @@ else()
                FILES_MATCHING PATTERN "*.so*" )
       install( FILES "${_INTDIR}/audacity.desktop"
                DESTINATION "${_DATADIR}/applications" )
-      install( FILES "${topdir}/LICENSE.txt" "${topdir}/README.txt"
+      install( FILES "${topdir}/LICENSE.txt" "${topdir}/README.md"
                DESTINATION "${_DATADIR}/doc/${AUDACITY_NAME}" )
       install( FILES "${_SRCDIR}/audacity.xml"
                DESTINATION "${_DATADIR}/mime/packages" )


### PR DESCRIPTION
Resolves: https://github.com/tenacityteam/tenacity/issues/142


<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] The code in this pull request is licensed under "GPLv2 or any later version"
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
