### PR TITLE
Implement toolbar edit mode

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -926,6 +926,9 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
    mTracks = &TrackList::Get( *project );
 
    mIsSnapped = false;
+   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+
+   mGrabber = nullptr;
 
    mIsRecording = false;
 
@@ -969,7 +972,13 @@ void AdornedRulerPanel::Refresh( bool eraseBackground, const wxRect *rect )
 
 void AdornedRulerPanel::UpdatePrefs()
 {
-   if (mNeedButtonUpdate) {
+   bool mode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   
+   if ( mode != mEditMode )
+   {
+	   mEditMode = mode;
+	   ReCreateButtons();
+   }else if (mNeedButtonUpdate) {
       // Visit this block once only in the lifetime of this panel
       mNeedButtonUpdate = false;
       // Do this first time setting of button status texts
@@ -1009,6 +1018,12 @@ void AdornedRulerPanel::ReCreateButtons()
       button = nullptr;
    }
 
+   if ( mGrabber )
+   {
+      mGrabber->Destroy();
+      mGrabber = nullptr;
+   }
+
    size_t iButton = 0;
    // Make the short row of time ruler pushbottons.
    // Don't bother with sizers.  Their sizes and positions are fixed.
@@ -1017,12 +1032,14 @@ void AdornedRulerPanel::ReCreateButtons()
 
    wxPoint position( 1, 0 );
 
-   Grabber * pGrabber = safenew Grabber(this, this->GetId());
-   pGrabber->SetAsSpacer( true );
-   //pGrabber->SetSize( 10, 27 ); // default is 10,27
-   pGrabber->SetPosition( position );
-
-   position.x = 12;
+   if ( mEditMode )
+   {
+      mGrabber = safenew Grabber(this, this->GetId());
+      mGrabber->SetAsSpacer( true );
+      //mGrabber->SetSize( 10, 27 ); // default is 10,27
+      mGrabber->SetPosition( position );
+      position.x = 12;
+   }else position.x = 0;
 
    auto size = theTheme.ImageSize( bmpRecoloredUpSmall );
    size.y = std::min(size.y, GetRulerHeight(false));

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -926,7 +926,7 @@ AdornedRulerPanel::AdornedRulerPanel(AudacityProject* project,
    mTracks = &TrackList::Get( *project );
 
    mIsSnapped = false;
-   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
 
    mGrabber = nullptr;
 
@@ -972,7 +972,7 @@ void AdornedRulerPanel::Refresh( bool eraseBackground, const wxRect *rect )
 
 void AdornedRulerPanel::UpdatePrefs()
 {
-   bool mode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   bool mode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
    
    if ( mode != mEditMode )
    {

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -976,8 +976,8 @@ void AdornedRulerPanel::UpdatePrefs()
    
    if ( mode != mEditMode )
    {
-	   mEditMode = mode;
-	   ReCreateButtons();
+      mEditMode = mode;
+      ReCreateButtons();
    }else if (mNeedButtonUpdate) {
       // Visit this block once only in the lifetime of this panel
       mNeedButtonUpdate = false;

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -13,6 +13,7 @@
 
 #include "CellularPanel.h"
 #include "widgets/Ruler.h" // member variable
+#include "widgets/Grabber.h" // mGrabber
 #include "Prefs.h"
 #include "ViewInfo.h" // for PlayRegion
 
@@ -142,6 +143,9 @@ private:
    double mQuickPlayPos;
 
    bool mIsSnapped;
+   bool mEditMode;
+
+   Grabber *mGrabber;
 
    PlayRegion mOldPlayRegion;
 

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -27,7 +27,7 @@ void OnEditMode(const CommandContext &context)
    auto &project = context.project;
    auto &commandManager = CommandManager::Get( project );
 
-   bool checked = !gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   bool checked = !gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
    gPrefs->Write(wxT("/GUI/Toolbars/EditMode"), checked);
    gPrefs->Flush();
    commandManager.Check(wxT("EditMode"), checked);
@@ -66,7 +66,7 @@ BaseItemSharedPtr ToolbarsMenu()
             /* i18n-hint: (verb)*/
 			Command( wxT("EditMode"), XXO("&Edit Mode (on/off)"),
 				FN(OnEditMode), AudioIONotBusyFlag(),
-				Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), false ) ),
+				Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), true ) ),
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),
                FN(OnResetToolBars), AlwaysEnabledFlag )
          ),

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -21,6 +21,19 @@ void OnResetToolBars(const CommandContext &context)
    ToolManager::OnResetToolBars(context);
 }
 
+void OnEditMode(const CommandContext &context)
+{
+   auto &project = context.project;
+   auto &commandManager = CommandManager::Get( project );
+
+   bool checked = !gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   gPrefs->Write(wxT("/GUI/Toolbars/EditMode"), checked);
+   gPrefs->Flush();
+   commandManager.Check(wxT("EditMode"), checked);
+
+   wxTheApp->AddPendingEvent(wxCommandEvent{ EVT_PREFS_UPDATE });
+}
+
 }; // struct Handler
 
 
@@ -48,8 +61,11 @@ BaseItemSharedPtr ToolbarsMenu()
    ( FinderScope{ findCommandHandler },
    Section( wxT("Toolbars"),
       Menu( wxT("Toolbars"), XXO("&Toolbars"),
-         Section( "Reset",
+         Section( "Manage",
             /* i18n-hint: (verb)*/
+			Command( wxT("EditMode"), XXO("&Edit Mode (on/off)"),
+				FN(OnEditMode), AlwaysEnabledFlag,
+				Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), false ) ),
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),
                FN(OnResetToolBars), AlwaysEnabledFlag )
          ),

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -64,9 +64,9 @@ BaseItemSharedPtr ToolbarsMenu()
       Menu( wxT("Toolbars"), XXO("&Toolbars"),
          Section( "Manage",
             /* i18n-hint: (verb)*/
-			Command( wxT("EditMode"), XXO("&Edit Mode (on/off)"),
-				FN(OnEditMode), AudioIONotBusyFlag(),
-				Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), true ) ),
+            Command( wxT("EditMode"), XXO("&Edit Mode (on/off)"),
+                FN(OnEditMode), AudioIONotBusyFlag(),
+                Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), true ) ),
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),
                FN(OnResetToolBars), AlwaysEnabledFlag )
          ),

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -5,6 +5,7 @@
 #include "../commands/CommandContext.h"
 #include "../commands/CommandManager.h"
 #include "../toolbars/ToolManager.h"
+#include "../CommonCommandFlags.h"
 
 /// Namespace for functions for View Toolbar menu
 namespace ToolbarActions {
@@ -64,7 +65,7 @@ BaseItemSharedPtr ToolbarsMenu()
          Section( "Manage",
             /* i18n-hint: (verb)*/
 			Command( wxT("EditMode"), XXO("&Edit Mode (on/off)"),
-				FN(OnEditMode), AlwaysEnabledFlag,
+				FN(OnEditMode), AudioIONotBusyFlag(),
 				Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), false ) ),
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),
                FN(OnResetToolBars), AlwaysEnabledFlag )

--- a/src/menus/ToolbarMenus.cpp
+++ b/src/menus/ToolbarMenus.cpp
@@ -64,7 +64,7 @@ BaseItemSharedPtr ToolbarsMenu()
       Menu( wxT("Toolbars"), XXO("&Toolbars"),
          Section( "Manage",
             /* i18n-hint: (verb)*/
-            Command( wxT("EditMode"), XXO("&Edit Mode (on/off)"),
+            Command( wxT("EditMode"), XXO("Edit &Mode (on/off)"),
                 FN(OnEditMode), AudioIONotBusyFlag(),
                 Options{}.CheckTest( wxT("/GUI/Toolbars/EditMode"), true ) ),
             Command( wxT("ResetToolbars"), XXO("Reset Toolb&ars"),

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -542,11 +542,11 @@ void ToolBar::ReCreateButtons()
       // Grabber is created only when editing, or when it's undocked
       // (as otherwise the undocked toolbar can't be moved around)
       if (mEditMode || !IsDocked())
-	  {
+      {
          // Create the grabber and add it to the main sizer
          mGrabber = safenew Grabber(this, mType);
          ms->Add(mGrabber, 0, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP | wxRIGHT, 1);
-	  }
+      }
       // Use a box sizer for laying out controls
       ms->Add((mHSizer = safenew wxBoxSizer(wxHORIZONTAL)), 1, wxEXPAND);
 
@@ -631,14 +631,14 @@ void ToolBar::UpdatePrefs()
 
    if ( editing != mEditMode )
    {
-	   mEditMode = editing;
-	   updated = true;
+      mEditMode = editing;
+      updated = true;
    }
 
    if ( updated )
    {
-	   ReCreateButtons();
-	   Updated();
+      ReCreateButtons();
+      Updated();
    }
 
    return;

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -346,7 +346,7 @@ ToolBar::ToolBar( AudacityProject &project,
    mHSizer = NULL;
    mVisible = false;
    mPositioned = false;
-   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
 
    mGrabber = NULL;
    mResizer = NULL;
@@ -627,7 +627,7 @@ void ToolBar::UpdatePrefs()
 #endif
 
    bool updated = false;
-   bool editing = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+   bool editing = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), true);
 
    if ( editing != mEditMode )
    {

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -346,7 +346,7 @@ ToolBar::ToolBar( AudacityProject &project,
    mHSizer = NULL;
    mVisible = false;
    mPositioned = false;
-   mEditMode = false;
+   mEditMode = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
 
    mGrabber = NULL;
    mResizer = NULL;

--- a/src/toolbars/ToolBar.cpp
+++ b/src/toolbars/ToolBar.cpp
@@ -346,6 +346,7 @@ ToolBar::ToolBar( AudacityProject &project,
    mHSizer = NULL;
    mVisible = false;
    mPositioned = false;
+   mEditMode = false;
 
    mGrabber = NULL;
    mResizer = NULL;
@@ -538,10 +539,14 @@ void ToolBar::ReCreateButtons()
       // Create the main sizer
       auto ms = std::make_unique<wxBoxSizer>(wxHORIZONTAL);
 
-      // Create the grabber and add it to the main sizer
-      mGrabber = safenew Grabber(this, mType);
-      ms->Add(mGrabber, 0, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP | wxRIGHT, 1);
-
+      // Grabber is created only when editing, or when it's undocked
+      // (as otherwise the undocked toolbar can't be moved around)
+      if (mEditMode || !IsDocked())
+	  {
+         // Create the grabber and add it to the main sizer
+         mGrabber = safenew Grabber(this, mType);
+         ms->Add(mGrabber, 0, wxEXPAND | wxALIGN_LEFT | wxALIGN_TOP | wxRIGHT, 1);
+	  }
       // Use a box sizer for laying out controls
       ms->Add((mHSizer = safenew wxBoxSizer(wxHORIZONTAL)), 1, wxEXPAND);
 
@@ -549,7 +554,7 @@ void ToolBar::ReCreateButtons()
       Populate();
 
       // Add some space for the resize border
-      if (IsResizable())
+      if (mEditMode && IsResizable())
       {
          // Create the resizer and add it to the main sizer
          mResizer = safenew ToolBarResizer(this);
@@ -621,6 +626,21 @@ void ToolBar::UpdatePrefs()
    }
 #endif
 
+   bool updated = false;
+   bool editing = gPrefs->Read(wxT("/GUI/Toolbars/EditMode"), false);
+
+   if ( editing != mEditMode )
+   {
+	   mEditMode = editing;
+	   updated = true;
+   }
+
+   if ( updated )
+   {
+	   ReCreateButtons();
+	   Updated();
+   }
+
    return;
 }
 
@@ -633,6 +653,15 @@ ToolDock *ToolBar::GetDock()
 }
 
 //
+// Returns whether or not edit mode is enabled
+//
+bool ToolBar::GetEditMode()
+{
+   return mEditMode;
+}
+
+
+//
 // Toggle the docked/floating state
 //
 void ToolBar::SetDocked( ToolDock *dock, bool pushed )
@@ -640,13 +669,16 @@ void ToolBar::SetDocked( ToolDock *dock, bool pushed )
    // Remember it
 //   mDock = dock;
 
-   // Change the tooltip of the grabber
+   if ( mGrabber )
+   {
+      // Change the tooltip of the grabber
 #if wxUSE_TOOLTIPS
-   mGrabber->SetToolTip( GetTitle() );
+      mGrabber->SetToolTip( GetTitle() );
 #endif
 
-   // Set the grabber button state
-   mGrabber->PushButton( pushed );
+      // Set the grabber button state
+      mGrabber->PushButton( pushed );
+   }
 
    if (mResizer)
    {

--- a/src/toolbars/ToolBar.h
+++ b/src/toolbars/ToolBar.h
@@ -121,6 +121,7 @@ class AUDACITY_DLL_API ToolBar /* not final */
    TranslatableString GetLabel();
    wxString GetSection();
    ToolDock *GetDock();
+   bool GetEditMode();
 
 private:
    void SetLabel(const wxString & label) override;
@@ -249,6 +250,7 @@ public:
    bool mVisible;
    bool mResizable;
    bool mPositioned; // true if position floating determined.
+   bool mEditMode;
 
  public:
 

--- a/src/toolbars/ToolManager.cpp
+++ b/src/toolbars/ToolManager.cpp
@@ -1177,7 +1177,7 @@ void ToolManager::OnMouse( wxMouseEvent & event )
          DoneDragging();
          return;
       }
-      else if( mDragDock && !event.ShiftDown() )
+      else if( mDragDock && !event.ShiftDown() && mDragBar->GetEditMode() )
       {
          // Trip over...everyone ashore that's going ashore...
          mDragDock->Dock( mDragBar, true, mDragBefore );
@@ -1249,7 +1249,7 @@ void ToolManager::OnMouse( wxMouseEvent & event )
          dock = mBotDock;
 
       // Looks like we have a winner...
-      if( dock )
+      if( dock && mDragBar->GetEditMode() )
       {
          wxPoint p;
          wxRect r;


### PR DESCRIPTION
Resolves: https://github.com/tenacityteam/tenacity/issues/122

This implements a new checkbox under View > Toolbars > Edit Mode (on/off), and it is checked ON by default. Unchecking it disables grabbing and resizing toolbars, which makes the user interface slightly cleaner and prevents accidental drags.

ON (default):
![image](https://user-images.githubusercontent.com/65567823/124939763-128a0380-e012-11eb-80bd-5cff4ef2ea37.png)

OFF:
![image](https://user-images.githubusercontent.com/65567823/124939561-e2dafb80-e011-11eb-8cc5-898047e3d74f.png)

Undocked toolbars continue to have grabbers, but they cannot be docked back with the main window unless edit mode is re-enabled.

- [x] The code in this pull request is licensed under "GPLv2 or any later version"\*
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*
