### PR TITLE
Remove `audacity_` prefix from CMake options

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -113,7 +113,7 @@ Alternatively, you can use **CLion**. If you chose to do so, open the directory 
 At the moment we only support **x86_64** builds. It is possible to build using AppleSilicon hardware but **mad** and **id3tag** should be disabled:
 
 ```
-cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=off ../tenacity
+cmake -GXCode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
 ```
 
 ## Linux & Other OS
@@ -127,7 +127,7 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
 2. Configure Tenacity using CMake:
    ```
    $ mkdir build && cd build
-   $ cmake -G "Unix Makefiles" -Daudacity_use_ffmpeg=loaded ../tenacity
+   $ cmake -G "Unix Makefiles" -Duse_ffmpeg=loaded ../tenacity
    ```
    By default, Debug build will be configured. To change that, pass `-DCMAKE_BUILD_TYPE=Release` to CMake.
 
@@ -163,9 +163,9 @@ On Linux it is possible to build Tenacity using (almost) only the libraries prov
 ```
 $ mkdir build && cd build
 $ cmake -G "Unix Makefiles" \
-        -Daudacity_use_ffmpeg=loaded \
-        -Daudacity_lib_preference=system \
-        -Daudacity_obey_system_dependencies=On \
+        -Duse_ffmpeg=loaded \
+        -Dlib_preference=system \
+        -Dobey_system_dependencies=On \
          ../tenacity
 ```
 

--- a/CMAKE_OPTIONS.md
+++ b/CMAKE_OPTIONS.md
@@ -2,36 +2,36 @@
 | :-------------------------------- | :----- | :--------- | :-------------------------------------------------------------- |
 | CMAKE_BUILD_TYPE                  | STRING | Debug      | Type of the build: Debug, Release, RelWithDebInfo, MinSizeRel   |
 | CMAKE_INSTALL_PREFIX              | PATH   | /usr/local | Install path prefix, prepended onto install directories.        |
-| audacity_lib_preference           | STRING | local      | Library preference [system (if available), local]               |
-| audacity_obey_system_dependencies | BOOL   | Off        | Use only system packages to satisfy dependencies                |
-| audacity_use_expat                | STRING | system     | Use expat library [system (if available), local, off]           |
-| audacity_use_ffmpeg               | STRING | loaded     | Use ffmpeg library [loaded, linked, off]                        |
-| audacity_use_flac                 | STRING | local      | Use flac library [system (if available), local, off]            |
-| audacity_use_id3tag               | STRING | local      | Use id3tag library [system (if available), local, off]          |
-| audacity_use_ladspa               | BOOL   | ON         | Use LADSPA plug-in support [on, off]                            |
-| audacity_use_libmad               | STRING | local      | Use libmad library [system (if available), local, off]          |
-| audacity_use_libmp3lame           | STRING | local      | Use libmp3lame library [system (if available), local, off]      |
-| audacity_use_lv2                  | STRING | local      | Use lv2 library [system (if available), local, off]             |
-| audacity_use_mad                  | STRING | local      | Use mad library [system (if available), local, off]             |
-| audacity_use_midi                 | STRING | local      | Use midi library [system (if available), local, off]            |
-| audacity_use_nyquist              | STRING | local      | Use nyquist library [local, off]                                |
-| audacity_use_ogg                  | STRING | local      | Use ogg library [system (if available), local, off]             |
-| audacity_use_pa_alsa              | BOOL   | YES        | Use the portaudio ALSA interface if available                   |
-| audacity_use_pa_jack              | STRING | linked     | Use the JACK audio interface if available [loaded, linked, off] |
-| audacity_use_pa_oss               | BOOL   | YES        | Use the OSS audio interface if available                        |
-| audacity_use_pch                  | BOOL   | YES        | Use precompiled headers [yes, no]                               |
-| audacity_use_portaudio            | STRING | local      | Use portaudio library [local]                                   |
-| audacity_use_portmixer            | STRING | local      | Use portmixer library [local, off]                              |
-| audacity_use_portsmf              | STRING | local      | Use portsmf library [system (if available), local, off]         |
-| audacity_use_sbsms                | STRING | local      | Use sbsms library [system (if available), local, off]           |
-| audacity_use_sndfile              | STRING | local      | Use sndfile library [system (if available), local]              |
-| audacity_use_soundtouch           | STRING | local      | Use soundtouch library [system (if available), local, off]      |
-| audacity_use_soxr                 | STRING | local      | Use soxr library [system (if available), local]                 |
-| audacity_use_sqlite               | STRING | local      | Use sqlite library [system (if available), local]               |
-| audacity_use_twolame              | STRING | local      | Use twolame library [system (if available), local, off]         |
-| audacity_use_vamp                 | STRING | local      | Use vamp library [system (if available), local, off]            |
-| audacity_use_vorbis               | STRING | local      | Use vorbis library [system (if available), local, off]          |
-| audacity_use_vst                  | BOOL   | ON         | Use VST2 plug-in support [on, off]                              |
-| audacity_use_wxwidgets            | STRING | local      | Use wxwidgets library [system (if available), local, off]       |
-| audacity_use_zlib                 | STRING | local      | Use zlib library [system (if available), local, off]            |
-| audacity_use_curl                 | STRING | local      | Use curl library [system (if available), local]                 |
+| lib_preference           | STRING | local      | Library preference [system (if available), local]               |
+| obey_system_dependencies | BOOL   | Off        | Use only system packages to satisfy dependencies                |
+| use_expat                | STRING | system     | Use expat library [system (if available), local, off]           |
+| use_ffmpeg               | STRING | loaded     | Use ffmpeg library [loaded, linked, off]                        |
+| use_flac                 | STRING | local      | Use flac library [system (if available), local, off]            |
+| use_id3tag               | STRING | local      | Use id3tag library [system (if available), local, off]          |
+| use_ladspa               | BOOL   | ON         | Use LADSPA plug-in support [on, off]                            |
+| use_libmad               | STRING | local      | Use libmad library [system (if available), local, off]          |
+| use_libmp3lame           | STRING | local      | Use libmp3lame library [system (if available), local, off]      |
+| use_lv2                  | STRING | local      | Use lv2 library [system (if available), local, off]             |
+| use_mad                  | STRING | local      | Use mad library [system (if available), local, off]             |
+| use_midi                 | STRING | local      | Use midi library [system (if available), local, off]            |
+| use_nyquist              | STRING | local      | Use nyquist library [local, off]                                |
+| use_ogg                  | STRING | local      | Use ogg library [system (if available), local, off]             |
+| use_pa_alsa              | BOOL   | YES        | Use the portaudio ALSA interface if available                   |
+| use_pa_jack              | STRING | linked     | Use the JACK audio interface if available [loaded, linked, off] |
+| use_pa_oss               | BOOL   | YES        | Use the OSS audio interface if available                        |
+| use_pch                  | BOOL   | YES        | Use precompiled headers [yes, no]                               |
+| use_portaudio            | STRING | local      | Use portaudio library [local]                                   |
+| use_portmixer            | STRING | local      | Use portmixer library [local, off]                              |
+| use_portsmf              | STRING | local      | Use portsmf library [system (if available), local, off]         |
+| use_sbsms                | STRING | local      | Use sbsms library [system (if available), local, off]           |
+| use_sndfile              | STRING | local      | Use sndfile library [system (if available), local]              |
+| use_soundtouch           | STRING | local      | Use soundtouch library [system (if available), local, off]      |
+| use_soxr                 | STRING | local      | Use soxr library [system (if available), local]                 |
+| use_sqlite               | STRING | local      | Use sqlite library [system (if available), local]               |
+| use_twolame              | STRING | local      | Use twolame library [system (if available), local, off]         |
+| use_vamp                 | STRING | local      | Use vamp library [system (if available), local, off]            |
+| use_vorbis               | STRING | local      | Use vorbis library [system (if available), local, off]          |
+| use_vst                  | BOOL   | ON         | Use VST2 plug-in support [on, off]                              |
+| use_wxwidgets            | STRING | local      | Use wxwidgets library [system (if available), local, off]       |
+| use_zlib                 | STRING | local      | Use zlib library [system (if available), local, off]            |
+| use_curl                 | STRING | local      | Use curl library [system (if available), local]                 |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,8 +127,10 @@ if( CCACHE_PROGRAM )
    set_property( GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}" )
 endif()
 
-# Define option() prefix
-set( _OPT "audacity_" )
+# Audacity sets this `audacity_` to prefix all CMake options which is not needed and this is not Audacity.
+# Keep this CMake variable here instead of removing it from the rest of the CMake code to minimize merge
+# conflicts with Audacity.
+set( _OPT "" )
 
 # Our very own project
 project( Audacity )

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -10,7 +10,7 @@ cmake_args=(
     -S .
     -B build
     -G "${AUDACITY_CMAKE_GENERATOR}"
-    -D audacity_use_pch=no
+    -D use_pch=no
     -D CMAKE_BUILD_TYPE="${AUDACITY_BUILD_TYPE}"
     -D CMAKE_INSTALL_PREFIX="${AUDACITY_INSTALL_PREFIX}"
 )
@@ -36,26 +36,26 @@ fi
 if [[ -n "${APPLE_CODESIGN_IDENTITY}" && "${OSTYPE}" == darwin* ]]; then
     cmake_args+=(
         -D APPLE_CODESIGN_IDENTITY="${APPLE_CODESIGN_IDENTITY}"
-        -D audacity_perform_codesign=yes
+        -D perform_codesign=yes
     )
 
     if [[ ${GIT_BRANCH} == release* ]]; then
         cmake_args+=(
             -D APPLE_NOTARIZATION_USER_NAME="${APPLE_NOTARIZATION_USER_NAME}"
             -D APPLE_NOTARIZATION_PASSWORD="${APPLE_NOTARIZATION_PASSWORD}"
-            -D audacity_perform_notarization=yes
+            -D perform_notarization=yes
         )
     fi
 elif [[ -n "${WINDOWS_CERTIFICATE}" && "${OSTYPE}" == msys* ]]; then
     # Windows certificate will be used from the environment
     cmake_args+=(
-        -D audacity_perform_codesign=yes
+        -D perform_codesign=yes
     )
 fi
 
 if [[ ${GIT_BRANCH} == release* ]]; then
     cmake_args+=(
-        -D audacity_package_manual=yes
+        -D package_manual=yes
     )
 fi
 


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #127

The CMake build scripts prefixed all options with `audacity_`. This prefixing is not conventional nor necessary, and this is not Audacity anymore. :)

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

- [x] The code in this pull request is licensed under "GPLv2 or any later version"\*
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required