### PR TITLE
docs: installing tenacity is not supported, yet.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -144,7 +144,7 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
    $ ./audacity
    ```
 
-In the moment, you are unable to install tenacity system-wide due conflits with libraries. You have to run Step 4 to use Tenacity. We are trying to fix that for the first stable release.
+At the moment, you are unable to install tenacity system-wide due conflits with libraries. You have to run Step 4 to use Tenacity. We are trying to fix that for the first stable release.
 
 ## Advanced
 

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -144,11 +144,7 @@ cmake -GXCode -T buildsystem=1 -Daudacity_use_mad="off" -Daudacity_use_id3tag=of
    $ ./audacity
    ```
 
-5. Installing Tenacity
-   ```
-   $ cd <build directory>
-   $ sudo make install
-   ```
+In the moment, you are unable to install tenacity system-wide due conflits with libraries. You have to run Step 4 to use Tenacity. We are trying to fix that for the first stable release.
 
 ## Advanced
 


### PR DESCRIPTION
Resolves: #172

Updates the documentation that installing tenacity is not yet supported

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*
