### PR TITLE
Fix synchronization race with hdiutil on macOS

### DIFF
--- a/mac/scripts/build_dist.sh
+++ b/mac/scripts/build_dist.sh
@@ -205,7 +205,7 @@ cp "${SRCROOT}/Resources/Audacity-DMG-background.png" "${DMG}/.background"
 ATTACHED=$(hdiutil info | awk "/\/Volumes\/${VOL}/{print \$1}")
 if [ -n "${ATTACHED}" ]
 then
-   #hdiutil detach "${ATTACHED}"
+   "${SRCROOT}/scripts/hdiutil_repeat.sh" detach "${ATTACHED}"
 fi
 
 # Create and mount the image

--- a/mac/scripts/hdiutil_repeat.sh
+++ b/mac/scripts/hdiutil_repeat.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$0: Error: Please upgrade Bash."; exit 1; }
+
+set -euxo pipefail
+
+max_retry=5
+counter=0
+
+while ! /usr/bin/hdiutil "$@"; do
+    sleep 1
+    ((counter++))
+    if [[ $counter -eq $max_retry ]]; then
+        echo "CPack failed despite retry attempts!"
+        exit 1
+    fi
+    echo "Trying CPack hdiutil call again. Try #$counter"
+done

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,6 +9,7 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
+    export CPACK_COMMAND_HDIUTIL="$(dirname "$(realpath "$0")")/../../mac/scripts/hdiutil_repeat.sh"
     cpack -C "${AUDACITY_BUILD_TYPE}" --verbose
 fi
 


### PR DESCRIPTION
Resolves: #40 and also is also a modification/fix of #198 (for github: closes #198).

This tries to repeat 'hdiutil detach' several times in both CI and
normal building mode. The first run may fail because of a
synchronization bug in CPack; this is a workaround.

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine [CI will do that, don't have a Mac at the moment]
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

(if something breaks while I'm away feel free to commit to my branch)