### PR TITLE
allow building with upstream PortAudio

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -162,6 +162,11 @@ endif ()
 
 
 addlib( portmixer          portmixer   PORTMIXER   NO    YES   "" )
+if (USE_PORTMIXER AND use_portaudio STREQUAL "system")
+  message(FATAL_ERROR "Tenacity's use of PortMixer requires using the vendored fork of PortAudio.\n"
+          "${_OPT}use_portaudio=local is required if ${_OPT}use_portmixer=local\n"
+          "Alternatively set ${_OPT}use_portmixer=off to keep ${_OPT}use_portaudio=system")
+endif()
 if (NOT USE_PORTMIXER AND
    "EXPERIMENTAL_AUTOMATED_INPUT_LEVEL_ADJUSTMENT" IN_LIST
       EXPERIMENTAL_OPTIONS_LIST )

--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -140,7 +140,7 @@ set_conan_vars_to_parent()
 #       directory          option      symbol      req   chk   version
 addlib( libsndfile         sndfile     SNDFILE     YES   YES   "sndfile >= 1.0.28" )
 addlib( libsoxr            soxr        SOXR        YES   YES   "soxr >= 0.1.1" )
-addlib( portaudio-v19      portaudio   PORTAUDIO   YES   YES   "" )
+addlib( portaudio-v19      portaudio   PORTAUDIO   YES   YES   "portaudio-2.0 >= 19" )
 addlib( sqlite             sqlite      SQLITE      YES   YES   "sqlite3 >= 3.32.0" )
 
 # Optional libraries

--- a/src/AudioIOBase.h
+++ b/src/AudioIOBase.h
@@ -21,6 +21,8 @@ Paul Licameli split from AudioIO.h
 #include <wx/weakref.h> // member variable
 #include "MemoryX.h"
 
+#include <portaudio.h>
+
 struct PaDeviceInfo;
 typedef void PaStream;
 


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #96

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

Test this by configuring CMake with ` -Duse_portaudio=system -Duse_portmixer=off`.

This allows Tenacity to work with PipeWire via the JACK API if PortAudio is up to date.

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required