### PR TITLE
CMake: fix search of LAME from system with module from Mixxx

### DIFF
--- a/cmake-proxies/CMakeLists.txt
+++ b/cmake-proxies/CMakeLists.txt
@@ -78,11 +78,10 @@ add_conan_lib(
 )
 
 add_conan_lib(
-   libmp3lame
+   mp3lame
    libmp3lame/3.100
    REQUIRED
-   INTERFACE_NAME libmp3lame::libmp3lame
-   PKG_CONFIG "lame >= 3.100"
+   INTERFACE_NAME mp3lame::mp3lame
 )
 
 add_conan_lib(

--- a/cmake-proxies/cmake-modules/Findmp3lame.cmake
+++ b/cmake-proxies/cmake-modules/Findmp3lame.cmake
@@ -1,0 +1,75 @@
+# This file is part of Mixxx, Digital DJ'ing software.
+# Copyright (C) 2001-2020 Mixxx Development Team
+# Distributed under the GNU General Public Licence (GPL) version 2 or any later
+# later version. See the LICENSE file for details.
+
+#[=======================================================================[.rst:
+Findmp3lame
+-----------
+
+Finds the LAME library.
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``mp3lame::mp3lame``
+  The LAME library
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This will define the following variables:
+
+``mp3lame_FOUND``
+  True if the system has the LAME library.
+``mp3lame_INCLUDE_DIRS``
+  Include directories needed to use LAME.
+``mp3lame_LIBRARIES``
+  Libraries needed to link to LAME.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``mp3lame_INCLUDE_DIR``
+  The directory containing ``lame/lame.h``.
+``mp3lame_LIBRARY``
+  The path to the LAME library.
+
+#]=======================================================================]
+
+find_path(mp3lame_INCLUDE_DIR
+  NAMES lame/lame.h
+  DOC "LAME include directory")
+mark_as_advanced(mp3lame_INCLUDE_DIR)
+
+find_library(mp3lame_LIBRARY
+  NAMES mp3lame mp3lame-static
+  DOC "LAME library"
+)
+mark_as_advanced(mp3lame_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  mp3lame
+  DEFAULT_MSG
+  mp3lame_LIBRARY
+  mp3lame_INCLUDE_DIR
+)
+
+if(mp3lame_FOUND)
+  set(mp3lame_LIBRARIES "${mp3lame_LIBRARY}")
+  set(mp3lame_INCLUDE_DIRS "${mp3lame_INCLUDE_DIR}")
+
+  if(NOT TARGET mp3lame::mp3lame)
+    add_library(mp3lame::mp3lame UNKNOWN IMPORTED)
+    set_target_properties(mp3lame::mp3lame
+      PROPERTIES
+        IMPORTED_LOCATION "${mp3lame_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${mp3lame_INCLUDE_DIR}"
+    )
+  endif()
+endif()

--- a/scripts/ci/dependencies.sh
+++ b/scripts/ci/dependencies.sh
@@ -30,6 +30,9 @@ else # Linux & others
     # Distribution packages
     if which apt-get; then
         apt_packages=(
+            # dependencies
+            libmp3lame-dev
+
             # Docker image
             file
             g++


### PR DESCRIPTION
Mixxx is licensed GPLv2 or later. This CMake module comes from:
https://github.com/mixxxdj/mixxx/blob/main/cmake/modules/Findmp3lame.cmake
Thanks to @Holzhaus for writing the CMake module.

Signed-off-by: Be <be@mixxx.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #225

I am not certain if this fully works yet because there are still other build problems using system libraries.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required