### PR TITLE
Corrected inaccurate build instructions and vague points in install instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -125,15 +125,24 @@ cmake -GXCode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
     ```
 
 2. Configure Tenacity using CMake:
-   ```
+   ```bash
    $ mkdir build && cd build
-   $ cmake -G "Unix Makefiles" -Duse_ffmpeg=loaded ../tenacity
+   $ cmake -G "Unix Makefiles" -Duse_ffmpeg=loaded ..
    ```
    By default, Debug build will be configured. To change that, pass `-DCMAKE_BUILD_TYPE=Release` to CMake.
 
 3. Build Tenacity:
-   ```
+   ```bash
    $ make -j`nproc`
+   ```
+   Note that this may slow your computer down quite a bit. To avoid this, you can use the alternate command:
+   ```bash
+   $ make -j`let numcores=$(nproc)-2 ; echo $numcores`
+   ```
+   Or, you can manually specify the number of CPU cores to use:
+   ```bash
+   $ make -j2
+   # Uses only 2 cores
    ```
 
 4. Testing the build:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -122,6 +122,7 @@ cmake -GXCode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
   
     ```
     $ git clone https://github.com/tenacityteam/tenacity/
+    $ cd tenacity
     ```
 
 2. Configure Tenacity using CMake:

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -138,9 +138,10 @@ cmake -GXCode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
    ```
    Note that this may slow your computer down quite a bit. To avoid this, you can use the alternate command:
    ```bash
-   $ make -j`let numcores=$(nproc)-2 ; echo $numcores`
+   $ make -j$(($(nproc)-2))
    ```
-   Or, you can manually specify the number of CPU cores to use:
+   This will use 2 fewer CPU cores than the default, which is to use the absolute maximum number of cores. Feel free to change this to `make -j$(($(nproc)-3))` if you want to use (MAX-3) cores, or any other custom values.
+   Alternatively, you can manually specify the number of CPU cores to use:
    ```bash
    $ make -j2
    # Uses only 2 cores


### PR DESCRIPTION
##  PR Description

Signed-off-by: Jacky Song <dixinlily@hotmail.com>

* The original install instructions for Linux systems had the incorrect instruction of `cmake -G "Unix Makefiles" -Duse_ffmpeg=loaded ../tenacity` where it should've actually been `cmake -G "Unix Makefiles" -Duse_ffmpeg=loaded ..`
* As well as fixing this, I also added an alternate instruction for running `make` to reduce processor resource use and to explicitly specify the different options of compiling (which may be confusing for beginners)

- [x] I have signed off my commits using `-s` or `Signed-off-by`
- [x] I made sure the code compiles on my machine (this change is not related to code)
- [x] I made sure there are no unnecessary changes in the code
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"