### PR TITLE
Add horizontal zooming/scrolling to "Plot Spectrum/Frequency Analysis" window

### DIFF
--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -98,6 +98,8 @@ enum {
 
    FreqVZoomSliderID,
    FreqVPanScrollerID,
+   FreqHZoomSliderID,
+   FreqHPanScrollerID,
    FreqExportButtonID,
    FreqAlgChoiceID,
    FreqSizeChoiceID,
@@ -171,6 +173,8 @@ BEGIN_EVENT_TABLE(FrequencyPlotDialog, wxDialogWrapper)
    EVT_SIZE(FrequencyPlotDialog::OnSize)
    EVT_SLIDER(FreqVZoomSliderID, FrequencyPlotDialog::OnZoomSlider)
    EVT_COMMAND_SCROLL(FreqVPanScrollerID, FrequencyPlotDialog::OnPanScroller)
+   EVT_SLIDER(FreqHZoomSliderID, FrequencyPlotDialog::OnZoomSlider)
+   EVT_COMMAND_SCROLL(FreqHPanScrollerID, FrequencyPlotDialog::OnPanScroller)
    EVT_CHOICE(FreqAlgChoiceID, FrequencyPlotDialog::OnAlgChoice)
    EVT_CHOICE(FreqSizeChoiceID, FrequencyPlotDialog::OnSizeChoice)
    EVT_CHOICE(FreqFuncChoiceID, FrequencyPlotDialog::OnFuncChoice)
@@ -366,35 +370,87 @@ void FrequencyPlotDialog::Populate()
       S.EndHorizontalLay();
 
       // -------------------------------------------------------------------
-      // ROW 2: Frequency ruler
+      // ROW 2: Frequency ruler, pan, and zoom
       // -------------------------------------------------------------------
 
+      // col0
       S.AddSpace(1);
 
-      S.StartHorizontalLay(wxEXPAND, 0);
+      // col1
+      S.StartVerticalLay(0);  // do not expand vertically
       {
-         hRuler  = safenew RulerPanel(
-            S.GetParent(), wxID_ANY, wxHORIZONTAL,
-            wxSize{ 100, 100 }, // Ruler can't handle small sizes
-            RulerPanel::Range{ 10, 20000 },
-            Ruler::RealFormat,
-            XO("Hz"),
-            RulerPanel::Options{}
-               .Log(true)
-               .Flip(true)
-               .LabelEdges(true)
-               .TickColour( theTheme.Colour( clrGraphLabels ) )
-         );
+         S.StartHorizontalLay(wxEXPAND, 0);  // expand horizontally, not vertically
+         {
+            hRuler  = safenew RulerPanel(
+               S.GetParent(), wxID_ANY, wxHORIZONTAL,
+               wxSize{ 100, 100 }, // Ruler can't handle small sizes
+               RulerPanel::Range{ 10, 20000 },
+               Ruler::RealFormat,
+               XO("Hz"),
+               RulerPanel::Options{}
+                  .Log(true)
+                  .Flip(true)
+                  .LabelEdges(true)
+                  .TickColour( theTheme.Colour( clrGraphLabels ) )
+            );
 
-         S.AddSpace(1, wxDefaultCoord);
-         S.Prop(1)
-            .Position(wxALIGN_LEFT | wxALIGN_TOP)
-            .AddWindow(hRuler);
-         S.AddSpace(1, wxDefaultCoord);
+            S.AddSpace(1, wxDefaultCoord);
+            S.Prop(1)
+               .Position(wxALIGN_LEFT | wxALIGN_TOP)
+               .AddWindow(hRuler);
+            S.AddSpace(1, wxDefaultCoord);
+         }
+         S.EndHorizontalLay();
+
+         S.StartHorizontalLay(wxEXPAND, 0);
+         {
+            hPanScroller = safenew wxScrollBar(S.GetParent(), FreqHPanScrollerID,
+               wxDefaultPosition, wxDefaultSize, wxSB_HORIZONTAL);
+#if wxUSE_ACCESSIBILITY
+            // so that name can be set on a standard control
+            hPanScroller->SetAccessible(safenew WindowAccessible(hPanScroller));
+#endif
+            S.Prop(1);
+            S
+               .Name(XO("Scroll Horizontal"))
+               .Position( wxALIGN_LEFT | wxTOP)
+               .AddWindow(hPanScroller);
+         }
+         S.EndHorizontalLay();
+
+         S.StartHorizontalLay(wxEXPAND, 0);
+         {
+            wxStaticBitmap *zi = safenew wxStaticBitmap(S.GetParent(), wxID_ANY, wxBitmap(ZoomOut));
+            S.Position(wxALIGN_CENTER)
+               .AddWindow(zi);
+
+            S.AddSpace(5);
+
+            hZoomSlider = safenew wxSliderWrapper(S.GetParent(), FreqHZoomSliderID, 100, 1, 100,
+               wxDefaultPosition, wxDefaultSize, wxSL_HORIZONTAL);
+            S.Prop(1);
+            S
+               .Name(XO("Zoom Horizontal"))
+               .Position(wxALIGN_CENTER_VERTICAL)
+               .AddWindow(hZoomSlider);
+#if wxUSE_ACCESSIBILITY
+            // so that name can be set on a standard control
+            hZoomSlider->SetAccessible(safenew WindowAccessible(hZoomSlider));
+#endif
+
+            S.AddSpace(5);
+
+            wxStaticBitmap *zo = safenew wxStaticBitmap(S.GetParent(), wxID_ANY, wxBitmap(ZoomIn));
+            S.Position(wxALIGN_CENTER)
+               .AddWindow(zo);
+         }
+         S.EndHorizontalLay();
       }
-      S.EndHorizontalLay();
+      S.EndVerticalLay();
 
+      // col2
       S.AddSpace(1);
+      // next row
 
       // -------------------------------------------------------------------
       // ROW 3: Spacer

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -753,16 +753,22 @@ void FrequencyPlotDialog::DrawPlot()
       return;
    }
 
-   float yRange = mYMax - mYMin;
-   float yTotal = yRange * ((float) vZoomSlider->GetValue() / 100.0f);
+   // Compute y axis ruler range, given current zoom level
+   float yTotal, yMax, yMin;
+   {
+      float yRange = mYMax - mYMin;
+      yTotal = yRange * ((float) vZoomSlider->GetValue() / 100.0f);
 
-   int sTotal = yTotal * 100;
-   int sRange = yRange * 100;
-   int sPos = vPanScroller->GetThumbPosition() + ((vPanScroller->GetThumbSize() - sTotal) / 2);
-    vPanScroller->SetScrollbar(sPos, sTotal, sRange, sTotal);
+      int sTotal = yTotal * 100;
+      int sRange = yRange * 100;
+      int sPos = vPanScroller->GetThumbPosition() + ((vPanScroller->GetThumbSize() - sTotal) / 2);
 
-   float yMax = mYMax - ((float)sPos / 100);
-   float yMin = yMax - yTotal;
+      // Set scrollbar size
+      vPanScroller->SetScrollbar(sPos, sTotal, sRange, sTotal);
+
+      yMax = mYMax - ((float)sPos / 100);
+      yMin = yMax - yTotal;
+   }
 
    // Set up y axis ruler
 

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -96,8 +96,8 @@ DEFINE_EVENT_TYPE(EVT_FREQWINDOW_RECALC);
 enum {
    FirstID = 7000,
 
-   FreqZoomSliderID,
-   FreqPanScrollerID,
+   FreqVZoomSliderID,
+   FreqVPanScrollerID,
    FreqExportButtonID,
    FreqAlgChoiceID,
    FreqSizeChoiceID,
@@ -169,8 +169,8 @@ static const char * ZoomOut[] = {
 BEGIN_EVENT_TABLE(FrequencyPlotDialog, wxDialogWrapper)
    EVT_CLOSE(FrequencyPlotDialog::OnCloseWindow)
    EVT_SIZE(FrequencyPlotDialog::OnSize)
-   EVT_SLIDER(FreqZoomSliderID, FrequencyPlotDialog::OnZoomSlider)
-   EVT_COMMAND_SCROLL(FreqPanScrollerID, FrequencyPlotDialog::OnPanScroller)
+   EVT_SLIDER(FreqVZoomSliderID, FrequencyPlotDialog::OnZoomSlider)
+   EVT_COMMAND_SCROLL(FreqVPanScrollerID, FrequencyPlotDialog::OnPanScroller)
    EVT_CHOICE(FreqAlgChoiceID, FrequencyPlotDialog::OnAlgChoice)
    EVT_CHOICE(FreqSizeChoiceID, FrequencyPlotDialog::OnSizeChoice)
    EVT_CHOICE(FreqFuncChoiceID, FrequencyPlotDialog::OnFuncChoice)
@@ -319,17 +319,17 @@ void FrequencyPlotDialog::Populate()
       {
          S.StartVerticalLay();
          {
-            mPanScroller = safenew wxScrollBar(S.GetParent(), FreqPanScrollerID,
+            vPanScroller = safenew wxScrollBar(S.GetParent(), FreqVPanScrollerID,
                wxDefaultPosition, wxDefaultSize, wxSB_VERTICAL);
 #if wxUSE_ACCESSIBILITY
             // so that name can be set on a standard control
-            mPanScroller->SetAccessible(safenew WindowAccessible(mPanScroller));
+            vPanScroller->SetAccessible(safenew WindowAccessible(vPanScroller));
 #endif
             S.Prop(1);
             S
                .Name(XO("Scroll"))
                .Position( wxALIGN_LEFT | wxTOP)
-               .AddWindow(mPanScroller);
+               .AddWindow(vPanScroller);
          }
          S.EndVerticalLay();
 
@@ -341,16 +341,16 @@ void FrequencyPlotDialog::Populate()
 
             S.AddSpace(5);
 
-            mZoomSlider = safenew wxSliderWrapper(S.GetParent(), FreqZoomSliderID, 100, 1, 100,
+            vZoomSlider = safenew wxSliderWrapper(S.GetParent(), FreqVZoomSliderID, 100, 1, 100,
                wxDefaultPosition, wxDefaultSize, wxSL_VERTICAL);
             S.Prop(1);
             S
                .Name(XO("Zoom"))
                .Position(wxALIGN_CENTER_HORIZONTAL)
-               .AddWindow(mZoomSlider);
+               .AddWindow(vZoomSlider);
 #if wxUSE_ACCESSIBILITY
             // so that name can be set on a standard control
-            mZoomSlider->SetAccessible(safenew WindowAccessible(mZoomSlider));
+            vZoomSlider->SetAccessible(safenew WindowAccessible(vZoomSlider));
 #endif
 
             S.AddSpace(5);
@@ -542,7 +542,7 @@ void FrequencyPlotDialog::Populate()
    //
    // I guess the only way round it would be to handle key actions
    // ourselves, but we'll leave that for a future date.
-//   gtk_widget_set_can_focus(mPanScroller->m_widget, true);
+//   gtk_widget_set_can_focus(vPanScroller->m_widget, true);
 #endif
 }
 
@@ -698,12 +698,12 @@ void FrequencyPlotDialog::DrawPlot()
    }
 
    float yRange = mYMax - mYMin;
-   float yTotal = yRange * ((float) mZoomSlider->GetValue() / 100.0f);
+   float yTotal = yRange * ((float) vZoomSlider->GetValue() / 100.0f);
 
    int sTotal = yTotal * 100;
    int sRange = yRange * 100;
-   int sPos = mPanScroller->GetThumbPosition() + ((mPanScroller->GetThumbSize() - sTotal) / 2);
-    mPanScroller->SetScrollbar(sPos, sTotal, sRange, sTotal);
+   int sPos = vPanScroller->GetThumbPosition() + ((vPanScroller->GetThumbSize() - sTotal) / 2);
+    vPanScroller->SetScrollbar(sPos, sTotal, sRange, sTotal);
 
    float yMax = mYMax - ((float)sPos / 100);
    float yMin = yMax - yTotal;
@@ -1046,7 +1046,7 @@ void FrequencyPlotDialog::Recalc()
    }
 
    // Prime the scrollbar
-   mPanScroller->SetScrollbar(0, (mYMax - mYMin) * 100, (mYMax - mYMin) * 100, 1);
+   vPanScroller->SetScrollbar(0, (mYMax - mYMin) * 100, (mYMax - mYMin) * 100, 1);
 
    DrawPlot();
 }
@@ -1123,7 +1123,7 @@ void FrequencyPlotDialog::UpdatePrefs()
       Show(false);
    }
 
-   auto zoomSlider = mZoomSlider->GetValue();
+   auto zoomSlider = vZoomSlider->GetValue();
    auto drawGrid = mGridOnOff->GetValue();
    auto sizeChoice = mSizeChoice->GetStringSelection();
    auto algChoice = mAlgChoice->GetSelection();
@@ -1135,7 +1135,7 @@ void FrequencyPlotDialog::UpdatePrefs()
 
    Populate();
 
-   mZoomSlider->SetValue(zoomSlider);
+   vZoomSlider->SetValue(zoomSlider);
 
    mDrawGrid = drawGrid;
    mGridOnOff->SetValue(drawGrid);

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -763,9 +763,11 @@ void FrequencyPlotDialog::DrawPlot()
       int sRange = yRange * 100;
       int sPos = vPanScroller->GetThumbPosition() + ((vPanScroller->GetThumbSize() - sTotal) / 2);
 
-      // Set scrollbar size
+      // Set scrollbar size and position
       vPanScroller->SetScrollbar(sPos, sTotal, sRange, sTotal);
 
+      // Recompute sPos, taking into account SetScrollbar() clamping the position.
+      sPos = vPanScroller->GetThumbPosition();
       yMax = mYMax - ((float)sPos / 100);
       yMin = yMax - yTotal;
    }

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -141,10 +141,12 @@ private:
    Floats mData;
    size_t mWindowSize;
 
+   /// Whether x axis is in log-frequency.
    bool mLogAxis;
+   /// The minimum y value to plot.
    float mYMin;
+   /// The maximum y value to plot.
    float mYMax;
-   float mYStep;
 
    std::unique_ptr<wxBitmap> mBitmap;
 

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -130,8 +130,8 @@ private:
    wxChoice *mSizeChoice;
    wxChoice *mFuncChoice;
    wxChoice *mAxisChoice;
-   wxScrollBar *mPanScroller;
-   wxSlider *mZoomSlider;
+   wxScrollBar *vPanScroller;
+   wxSlider *vZoomSlider;
    wxTextCtrl *mCursorText;
    wxTextCtrl *mPeakText;
 

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -158,6 +158,12 @@ private:
    int mMouseX;
    int mMouseY;
 
+   static constexpr float NO_CURSOR = -1.f;
+   /// Frequency/period under the mouse cursor, if present.
+   float mCursorXLeft = NO_CURSOR;
+   /// Frequency/period 1 pixel to the right of the mouse cursor, if present.
+   float mCursorXRight = NO_CURSOR;
+
    std::unique_ptr<SpectrumAnalyst> mAnalyst;
 
    DECLARE_EVENT_TABLE()

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -132,6 +132,8 @@ private:
    wxChoice *mAxisChoice;
    wxScrollBar *vPanScroller;
    wxSlider *vZoomSlider;
+   wxScrollBar *hPanScroller;
+   wxSlider *hZoomSlider;
    wxTextCtrl *mCursorText;
    wxTextCtrl *mPeakText;
 

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -18,6 +18,7 @@
 #include "SampleFormat.h"
 #include "SpectrumAnalyst.h"
 #include "widgets/wxPanelWrapper.h" // to inherit
+#include "NumberScale.h" // member variable
 
 class wxMemoryDC;
 class wxScrollBar;
@@ -149,6 +150,8 @@ private:
    float mYMin;
    /// The maximum y value to plot.
    float mYMax;
+
+   NumberScale hNumberScale;
 
    std::unique_ptr<wxBitmap> mBitmap;
 


### PR DESCRIPTION
Also resolves pre-existing bugs (not reported):

- Zooming out doesn't clamp vertical scroll until next redraw ([video](https://youtu.be/CrzcWWTBoc4)).
- When resizing the window horizontally with a cursor active, the cursor remains on the same pixel but changes frequency ([video](https://youtu.be/aKZL80_Mrtw)).

This adds the ability to zoom and scroll the spectrum plot dialog (not track spectrogram) horizontally in frequency or period.

This makes larger FFT sizes more usable, since you can zoom into peaks which were previously too narrow to see the amplitude precisely. Additionally, you can zoom into regions of interest and hide unwanted portions of the spectrogram (like treble or in logarithmic scale, low bass).

![Screenshot of horizontally zooming into spectrum viewer](https://user-images.githubusercontent.com/913957/125222284-9a744580-e27e-11eb-8c44-d09f2359ef9c.png)

## Details

I rewrote the frequency viewer code to use `NumberScale` for converting between pixels and frequencies, instead of the hard-coded addition/multiplication loops used beforehand. This changes the exact shape of the plot slightly, even when not zoomed in. Using a `NumberScale` results in less rounding errors than repeated float32 addition or multiplication (and better plot accuracy for the right side of absurdly wide 16k-pixel-wide windows). I eliminated the `xMax-xStep` when computing the maximum value of the horizontal ruler, though I don't think it has an appreciable effect on the plot or cursor positioning (and doesn't affect the accuracy of peak-finding).

The primary motivation for this was because it simplified the process of zooming into part of the available frequency range. Additionally, it simplified the code and made it more declarative. This also makes it easy to add support for `NumberScale`'s Mel/Bark/ERB/Period scale modes in the future.

## Future improvements (not implemented yet, I may or may not implement)

- In the future, the spectrum plot could add options for Mel/Bark/ERB/Period scaling, instead of just linear and log.
- Zoom level is saved while Tenacity is open, but horizontal scrolling resets to centered when closing the dialog. This is no worse than vertical scale and zoom, but maybe it could be improved.
- Dragging the zoom slider now results in zooming in slightly to the left of the center of the plot ([video](https://youtu.be/P6AmwVeSxBI)).
	- This is because every change in zoom level recomputes the horizontal scrollbar's size and position, rounding the position down to the nearest integer. The rounding errors accumulate over many updates.
	- This needs to be solved by storing the intended center/boundaries of the viewport (either its frequency or position) independently of the scrollbar.
- Changing between linear and logarithmic scales, or changing FFT size, causes the plot to shift around. This is because the scrollbar position is maintained, not the minimum and maximum frequencies shown.
- Adding support for panning (dragging or middle-dragging), scrolling ([shift-]wheel), and/or zooming (ctrl-[shift-]scroll) into the plot.
	- My plan is for ctrl-scroll to zoom into the mouse cursor, rather than the center of the plot. This should make it easier to zoom into a particular part of the plot (generally low frequencies). However, computing changes to scrollbar position based on mouse position and scroll events (not just the current position of scrollbars and sliders) requires more planning to get right.

I'm still working on the best approach to solve the zoom together, which I will submit in a future pull request.

My currently planned approach (in a currently-private Google doc) involves storing extra information for the current zoom/frequency state, and having user action callbacks alter this state (in addition to resizing and positioning the scrollbar). The on-screen plot's viewport position/size will depend on internal state, rather than depending on the zoom slider and scrollbar widgets. Additionally, `FrequencyPlotDialog::DrawPlot()` will no longer set the scrollbar position, but only draw the plot.

## Potential issues

While testing my changes, I managed to get the GUI into a state where some of the widgets were stuck in place and glitched out behind other widgets when resizing the window vertically ([video](https://youtu.be/ZiLiS9O7-gU)). I have not been able to reproduce this since. It may be a pre-existing Wx/GTK bug.

On KDE, when closing the "Frequency Analysis" window when it's wider than the screen, the sides of the window can't be used to resize it until I've used the top/bottom or a corner to resize the window. I don't think this is related to my changes.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required