### PR TITLE
[translation] Better german translation

### DIFF
--- a/locale/de.po
+++ b/locale/de.po
@@ -841,7 +841,7 @@ msgstr "Deaktiviert"
 #. i18n-hint: Information about when audacity was compiled follows
 #: src/AboutDialog.cpp
 msgid "The Build"
-msgstr "Die Build"
+msgstr "Build Informationen"
 
 #: src/AboutDialog.cpp
 msgid "Program build date:"


### PR DESCRIPTION
In the build information window in German the title was "Die Build" which is a translation from "The Build", but "Die Build" doesn't really sound good in german.
Just putting "Build Informationen" read/sounds much better imo.

- [X] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [X] I made sure the code compiles on my machine
- [X] I made sure there are no unnecessary changes in the code\*
- [X] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [X] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*