### PR TITLE
Rebranding: Replace 'Audacity: A Digital Audio Editor' in source files

### DIFF
--- a/src/AColor.cpp
+++ b/src/AColor.cpp
@@ -1,7 +1,7 @@
 
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AColor.cpp
 

--- a/src/AColor.h
+++ b/src/AColor.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AColor.h
 

--- a/src/AColorResources.h
+++ b/src/AColorResources.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file AColorResources.h
   @brief RGB data of 'Color (New)' spectrogram color scheme

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AboutDialog.cpp
 

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AboutDialog.h
 

--- a/src/ActiveProjects.cpp
+++ b/src/ActiveProjects.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ActiveProjects.cpp
 

--- a/src/ActiveProjects.h
+++ b/src/ActiveProjects.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ActiveProjects.h
 

--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AdornedRulerPanel.cpp
 

--- a/src/AdornedRulerPanel.h
+++ b/src/AdornedRulerPanel.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AdornedRulerPanel.h
 

--- a/src/AllThemeResources.cpp
+++ b/src/AllThemeResources.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  AllThemeResources.cpp
  

--- a/src/AllThemeResources.h
+++ b/src/AllThemeResources.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AllThemeResources.h
 

--- a/src/AttachedVirtualFunction.h
+++ b/src/AttachedVirtualFunction.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 @file AttachedVirtualFunction.h
 @brief Utility for non-intrusive definition of a new method on a base class

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudacityApp.cpp
 

--- a/src/AudacityApp.h
+++ b/src/AudacityApp.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudacityApp.h
 

--- a/src/AudacityException.cpp
+++ b/src/AudacityException.cpp
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file AudacityException.cpp
   @brief Implements AudacityException and related

--- a/src/AudacityException.h
+++ b/src/AudacityException.h
@@ -3,7 +3,7 @@
 
 /*!********************************************************************
 
- Audacity: A Digital Audio Editor
+ Tenacity
 
  @file AudacityException.h
  @brief Declare abstract class AudacityException, some often-used subclasses, and @ref GuardedCall

--- a/src/AudacityFileConfig.cpp
+++ b/src/AudacityFileConfig.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 AudacityFileConfig.cpp
 

--- a/src/AudacityFileConfig.h
+++ b/src/AudacityFileConfig.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 @file AudacityFileConfig.h
 @brief Extend FileConfig with application-specific behavior

--- a/src/AudacityHeaders.cpp
+++ b/src/AudacityHeaders.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudacityHeaders.cpp
 

--- a/src/AudacityHeaders.h
+++ b/src/AudacityHeaders.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudacityHeaders.h
 

--- a/src/AudacityLogger.cpp
+++ b/src/AudacityLogger.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudacityLogger.cpp
 

--- a/src/AudacityLogger.h
+++ b/src/AudacityLogger.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudacityLogger.h
 

--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudioIO.cpp
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudioIO.h
 

--- a/src/AudioIOBase.cpp
+++ b/src/AudioIOBase.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 AudioIOBase.cpp
 

--- a/src/AudioIOBase.h
+++ b/src/AudioIOBase.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 AudioIOBase.h
 

--- a/src/AudioIOListener.h
+++ b/src/AudioIOListener.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   AudioIOListener.h
 

--- a/src/AutoRecoveryDialog.cpp
+++ b/src/AutoRecoveryDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 AutoRecoveryDialog.cpp
 

--- a/src/AutoRecoveryDialog.h
+++ b/src/AutoRecoveryDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 AutoRecoveryDialog.h
 

--- a/src/BatchCommandDialog.cpp
+++ b/src/BatchCommandDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   BatchCommandDialog.cpp
 

--- a/src/BatchCommandDialog.h
+++ b/src/BatchCommandDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   BatchCommandDialog.h
 

--- a/src/BatchCommands.cpp
+++ b/src/BatchCommands.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   MacroCommands.cpp
 

--- a/src/BatchCommands.h
+++ b/src/BatchCommands.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   MacroCommands.h
 

--- a/src/BatchProcessDialog.cpp
+++ b/src/BatchProcessDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ApplyMacroDialog.cpp
 

--- a/src/BatchProcessDialog.h
+++ b/src/BatchProcessDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   BatchProcessDialog.h
 

--- a/src/Benchmark.cpp
+++ b/src/Benchmark.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Benchmark.cpp
 

--- a/src/Benchmark.h
+++ b/src/Benchmark.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Benchmark.h
 

--- a/src/CellularPanel.cpp
+++ b/src/CellularPanel.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   CellularPanel.cpp
 

--- a/src/CellularPanel.h
+++ b/src/CellularPanel.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Tenacity
 
  CellularPanel.h
 

--- a/src/ClientData.h
+++ b/src/ClientData.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 @file ClientData.h
 @brief Utility ClientData::Site to register hooks into a host class that attach client data

--- a/src/ClientDataHelpers.h
+++ b/src/ClientDataHelpers.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 @file ClientDataHelpers.h
 @brief Some implementation details for ClientData

--- a/src/Clipboard.cpp
+++ b/src/Clipboard.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Clipboard.cpp
 

--- a/src/Clipboard.h
+++ b/src/Clipboard.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Clipboard.h
 

--- a/src/CommonCommandFlags.cpp
+++ b/src/CommonCommandFlags.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 CommonCommandFlags.cpp
 

--- a/src/CommonCommandFlags.h
+++ b/src/CommonCommandFlags.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 CommonCommandFlags.h
 

--- a/src/CrossFade.cpp
+++ b/src/CrossFade.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   CrossFade.cpp
 

--- a/src/CrossFade.h
+++ b/src/CrossFade.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   CrossFade.h
 

--- a/src/DBConnection.cpp
+++ b/src/DBConnection.cpp
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 @file DBConnection.cpp
 @brief Implements DBConnection

--- a/src/DBConnection.h
+++ b/src/DBConnection.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 @file DBConnection.h
 @brief Declare DBConnection, which maintains database connection and associated status and background thread

--- a/src/Dependencies.cpp
+++ b/src/Dependencies.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2008 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/Dependencies.h
+++ b/src/Dependencies.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2008 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/DeviceChange.cpp
+++ b/src/DeviceChange.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   DeviceChange.cpp
 

--- a/src/DeviceChange.h
+++ b/src/DeviceChange.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   DeviceChange.h
 

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   DeviceManager.h
 

--- a/src/Diags.cpp
+++ b/src/Diags.cpp
@@ -1,7 +1,7 @@
 
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Diags.cpp
 

--- a/src/Diags.h
+++ b/src/Diags.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Diags.h
 

--- a/src/Dither.cpp
+++ b/src/Dither.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Dither.cpp
 

--- a/src/Dither.h
+++ b/src/Dither.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Steve Harris
   Markus Meyer

--- a/src/Envelope.cpp
+++ b/src/Envelope.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Envelope.cpp
 

--- a/src/Envelope.h
+++ b/src/Envelope.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Envelope.h
 

--- a/src/EnvelopeEditor.cpp
+++ b/src/EnvelopeEditor.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   EnvelopeEditor.cpp
 

--- a/src/EnvelopeEditor.h
+++ b/src/EnvelopeEditor.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   EnvelopeEditor.h
 

--- a/src/FFmpeg.cpp
+++ b/src/FFmpeg.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 FFmpeg.cpp
 

--- a/src/FFmpeg.h
+++ b/src/FFmpeg.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 FFmpeg.h
 

--- a/src/FileFormats.cpp
+++ b/src/FileFormats.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FileFormats.cpp
 

--- a/src/FileFormats.h
+++ b/src/FileFormats.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FileFormats.h
 

--- a/src/FileIO.cpp
+++ b/src/FileIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FileIO.cpp
 

--- a/src/FileIO.h
+++ b/src/FileIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FileIO.h
 

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FileNames.cpp
 

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FileNames.h
 

--- a/src/FreqWindow.cpp
+++ b/src/FreqWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FreqWindow.cpp
 

--- a/src/FreqWindow.h
+++ b/src/FreqWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   FreqWindow.h
 

--- a/src/HelpText.cpp
+++ b/src/HelpText.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   HelpText.cpp
 

--- a/src/HelpText.h
+++ b/src/HelpText.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   HelpText.h
 

--- a/src/HistoryWindow.cpp
+++ b/src/HistoryWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   HistoryWindow.cpp
 

--- a/src/HistoryWindow.h
+++ b/src/HistoryWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   HistoryWindow.h
 

--- a/src/HitTestResult.h
+++ b/src/HitTestResult.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 HitTestResult.h
 

--- a/src/ImageManipulation.cpp
+++ b/src/ImageManipulation.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ImageManipulation.cpp
 

--- a/src/ImageManipulation.h
+++ b/src/ImageManipulation.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ImageManipulation.h
 

--- a/src/InterpolateAudio.cpp
+++ b/src/InterpolateAudio.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   InterpolateAudio.cpp
 

--- a/src/InterpolateAudio.h
+++ b/src/InterpolateAudio.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   InterpolateAudio.h
 

--- a/src/KeyboardCapture.cpp
+++ b/src/KeyboardCapture.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  KeyboardCapture.cpp
  

--- a/src/KeyboardCapture.h
+++ b/src/KeyboardCapture.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   KeyboardCapture.h
 

--- a/src/LabelDialog.cpp
+++ b/src/LabelDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LabelDialog.cpp
 

--- a/src/LabelDialog.h
+++ b/src/LabelDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LabelDialog.h
 

--- a/src/LabelTrack.cpp
+++ b/src/LabelTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LabelTrack.cpp
 

--- a/src/LabelTrack.h
+++ b/src/LabelTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LabelTrack.h
 

--- a/src/LangChoice.cpp
+++ b/src/LangChoice.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LangChoice.cpp
 

--- a/src/LangChoice.h
+++ b/src/LangChoice.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LangChoice.h
 

--- a/src/Legacy.cpp
+++ b/src/Legacy.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Legacy.cpp
 

--- a/src/Legacy.h
+++ b/src/Legacy.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Legacy.h
 

--- a/src/Lyrics.cpp
+++ b/src/Lyrics.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Lyrics.cpp
 

--- a/src/Lyrics.h
+++ b/src/Lyrics.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Lyrics.h
 

--- a/src/LyricsWindow.cpp
+++ b/src/LyricsWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LyricsWindow.cpp
 

--- a/src/LyricsWindow.h
+++ b/src/LyricsWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   LyricsWindow.h
 

--- a/src/MacroMagic.h
+++ b/src/MacroMagic.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   MacroMagic.h
 

--- a/src/Matrix.cpp
+++ b/src/Matrix.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Matrix.cpp
 

--- a/src/Matrix.h
+++ b/src/Matrix.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Matrix.h
 

--- a/src/Menus.cpp
+++ b/src/Menus.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Menus.cpp
 

--- a/src/Menus.h
+++ b/src/Menus.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Menus.h
 

--- a/src/Mix.cpp
+++ b/src/Mix.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Mix.cpp
 

--- a/src/Mix.h
+++ b/src/Mix.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Mix.h
 

--- a/src/MixerBoard.cpp
+++ b/src/MixerBoard.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   MixerBoard.cpp
 

--- a/src/MixerBoard.h
+++ b/src/MixerBoard.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   MixerBoard.h
 

--- a/src/ModuleManager.cpp
+++ b/src/ModuleManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ModuleManager.cpp
 

--- a/src/ModuleManager.h
+++ b/src/ModuleManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ModuleManager.h
 

--- a/src/ModuleSettings.cpp
+++ b/src/ModuleSettings.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file ModuleSettings.cpp
 

--- a/src/ModuleSettings.h
+++ b/src/ModuleSettings.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file ModuleSettings.h
 

--- a/src/NoteTrack.cpp
+++ b/src/NoteTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   NoteTrack.cpp
 

--- a/src/NoteTrack.h
+++ b/src/NoteTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   NoteTrack.h
 

--- a/src/NumberScale.h
+++ b/src/NumberScale.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 NumberScale.h
 

--- a/src/PitchName.cpp
+++ b/src/PitchName.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2012 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/PitchName.h
+++ b/src/PitchName.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2013 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/PlatformCompatibility.cpp
+++ b/src/PlatformCompatibility.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   PlatformCompatibility.cpp
 

--- a/src/PlatformCompatibility.h
+++ b/src/PlatformCompatibility.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   PlatformCompatibility.h
 

--- a/src/PlaybackSchedule.cpp
+++ b/src/PlaybackSchedule.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  PlaybackSchedule.cpp
  

--- a/src/PlaybackSchedule.h
+++ b/src/PlaybackSchedule.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  PlaybackSchedule.h
  

--- a/src/PluginManager.cpp
+++ b/src/PluginManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   PluginManager.cpp
 

--- a/src/PluginManager.h
+++ b/src/PluginManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   PluginManager.h
 

--- a/src/PluginRegistrationDialog.cpp
+++ b/src/PluginRegistrationDialog.cpp
@@ -1,6 +1,6 @@
 /*!*********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file PluginRegistrationDialog.cpp
 

--- a/src/PluginRegistrationDialog.h
+++ b/src/PluginRegistrationDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   PluginRegistrationDialog.h
 

--- a/src/Prefs.cpp
+++ b/src/Prefs.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Prefs.cpp
 

--- a/src/Prefs.h
+++ b/src/Prefs.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Prefs.h
 

--- a/src/Printing.cpp
+++ b/src/Printing.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Printing.cpp
 

--- a/src/Printing.h
+++ b/src/Printing.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Printing.h
 

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Profiler.cpp
 

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Profiler.h
 

--- a/src/Project.cpp
+++ b/src/Project.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Project.cpp
 

--- a/src/Project.h
+++ b/src/Project.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Project.h
 

--- a/src/ProjectAudioIO.cpp
+++ b/src/ProjectAudioIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectAudioIO.cpp
 

--- a/src/ProjectAudioIO.h
+++ b/src/ProjectAudioIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectAudioIO.h
 

--- a/src/ProjectAudioManager.cpp
+++ b/src/ProjectAudioManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectAudioManager.cpp
 

--- a/src/ProjectAudioManager.h
+++ b/src/ProjectAudioManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectAudioManager.h
 

--- a/src/ProjectFSCK.cpp
+++ b/src/ProjectFSCK.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ProjectFSCK.cpp
 

--- a/src/ProjectFSCK.h
+++ b/src/ProjectFSCK.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ProjectFSCK.h
 

--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectFileIO.cpp
 

--- a/src/ProjectFileIO.h
+++ b/src/ProjectFileIO.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectFileIO.h
 

--- a/src/ProjectFileIORegistry.cpp
+++ b/src/ProjectFileIORegistry.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ProjectFileIORegistry.cpp
 

--- a/src/ProjectFileIORegistry.h
+++ b/src/ProjectFileIORegistry.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ProjectFileIORegistry.h
 

--- a/src/ProjectFileManager.cpp
+++ b/src/ProjectFileManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectFileManager.cpp
 

--- a/src/ProjectFileManager.h
+++ b/src/ProjectFileManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectFileManager.h
 

--- a/src/ProjectHistory.cpp
+++ b/src/ProjectHistory.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectHistory.cpp
 

--- a/src/ProjectHistory.h
+++ b/src/ProjectHistory.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectHistory.h
 

--- a/src/ProjectManager.cpp
+++ b/src/ProjectManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectManager.cpp
 

--- a/src/ProjectManager.h
+++ b/src/ProjectManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectManager.h
 

--- a/src/ProjectSelectionManager.cpp
+++ b/src/ProjectSelectionManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectSelectionManager.cpp
 

--- a/src/ProjectSelectionManager.h
+++ b/src/ProjectSelectionManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectSelectionManager.cpp
 

--- a/src/ProjectSerializer.cpp
+++ b/src/ProjectSerializer.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2010 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/ProjectSerializer.h
+++ b/src/ProjectSerializer.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2010 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/ProjectSettings.cpp
+++ b/src/ProjectSettings.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectSettings.cpp
 

--- a/src/ProjectSettings.h
+++ b/src/ProjectSettings.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectSettings.h
 

--- a/src/ProjectStatus.cpp
+++ b/src/ProjectStatus.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectStatus.h
 

--- a/src/ProjectStatus.h
+++ b/src/ProjectStatus.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectStatus.h
 

--- a/src/ProjectWindow.cpp
+++ b/src/ProjectWindow.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectWindow.cpp
 

--- a/src/ProjectWindow.h
+++ b/src/ProjectWindow.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectWindow.h
 

--- a/src/ProjectWindowBase.cpp
+++ b/src/ProjectWindowBase.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectWindowBase.cpp
 

--- a/src/ProjectWindowBase.h
+++ b/src/ProjectWindowBase.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ProjectWindowBase.h
 

--- a/src/RealFFTf48x.cpp
+++ b/src/RealFFTf48x.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
 
    RealFFT48x.cpp
 

--- a/src/RefreshCode.h
+++ b/src/RefreshCode.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 RefreshCode.h
 

--- a/src/Registrar.h
+++ b/src/Registrar.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Registrar.h
 

--- a/src/Registry.cpp
+++ b/src/Registry.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 Registry.cpp
 

--- a/src/Registry.h
+++ b/src/Registry.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 Registry.h
 

--- a/src/Resample.cpp
+++ b/src/Resample.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2012 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/Resample.h
+++ b/src/Resample.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
    Audacity(R) is copyright (c) 1999-2012 Audacity Team.
    License: GPL v2.  See License.txt.
 

--- a/src/RingBuffer.cpp
+++ b/src/RingBuffer.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   RingBuffer.cpp
 

--- a/src/RingBuffer.h
+++ b/src/RingBuffer.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   RingBuffer.h
 

--- a/src/SampleBlock.cpp
+++ b/src/SampleBlock.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 SampleBlock.cpp
 

--- a/src/SampleBlock.h
+++ b/src/SampleBlock.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 SampleBlock.h
 

--- a/src/SampleFormat.cpp
+++ b/src/SampleFormat.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SampleFormat.h
 

--- a/src/SampleFormat.h
+++ b/src/SampleFormat.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file SampleFormat.h
 

--- a/src/Screenshot.cpp
+++ b/src/Screenshot.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Screenshot.cpp
 

--- a/src/Screenshot.h
+++ b/src/Screenshot.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Screenshot.h
 

--- a/src/SelectUtilities.cpp
+++ b/src/SelectUtilities.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  SelectUtilities.cpp
  

--- a/src/SelectUtilities.h
+++ b/src/SelectUtilities.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  SelectUtilities.h
  

--- a/src/SelectedRegion.cpp
+++ b/src/SelectedRegion.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 SelectedRegion.cpp
 

--- a/src/SelectedRegion.h
+++ b/src/SelectedRegion.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SelectedRegion.h
 

--- a/src/SelectionState.cpp
+++ b/src/SelectionState.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Tenacity
 
  SelectionState.h
 

--- a/src/SelectionState.h
+++ b/src/SelectionState.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Tenacity
 
  SelectionState.h
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Sequence.cpp
 

--- a/src/Sequence.h
+++ b/src/Sequence.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Sequence.h
 

--- a/src/Shuttle.h
+++ b/src/Shuttle.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Shuttle.h
 

--- a/src/ShuttleGetDefinition.cpp
+++ b/src/ShuttleGetDefinition.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ShuttleGetDefinition.cpp
 

--- a/src/ShuttleGetDefinition.h
+++ b/src/ShuttleGetDefinition.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ShuttleGetDefinition.h
 

--- a/src/ShuttleGui.cpp
+++ b/src/ShuttleGui.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ShuttleGui.cpp
 

--- a/src/ShuttleGui.h
+++ b/src/ShuttleGui.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ShuttleGui.h
 

--- a/src/ShuttlePrefs.cpp
+++ b/src/ShuttlePrefs.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ShuttlePrefs.cpp
 

--- a/src/ShuttlePrefs.h
+++ b/src/ShuttlePrefs.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ShuttlePrefs.h
 

--- a/src/Snap.cpp
+++ b/src/Snap.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Snap.cpp
 

--- a/src/Snap.h
+++ b/src/Snap.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Snap.h
 

--- a/src/SoundActivatedRecord.cpp
+++ b/src/SoundActivatedRecord.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SoundActivatedRecord.cpp
 

--- a/src/SoundActivatedRecord.h
+++ b/src/SoundActivatedRecord.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SoundActivatedRecord.cpp
 

--- a/src/Spectrum.cpp
+++ b/src/Spectrum.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Spectrum.cpp
 

--- a/src/Spectrum.h
+++ b/src/Spectrum.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Spectrum.h
 

--- a/src/SpectrumAnalyst.cpp
+++ b/src/SpectrumAnalyst.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SpectrumAnalyst.cpp
 

--- a/src/SpectrumAnalyst.h
+++ b/src/SpectrumAnalyst.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SpectrumAnalyst.h
 

--- a/src/SplashDialog.cpp
+++ b/src/SplashDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SplashDialog.cpp
 

--- a/src/SplashDialog.h
+++ b/src/SplashDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   SplashDialog.h
 

--- a/src/SqliteSampleBlock.cpp
+++ b/src/SqliteSampleBlock.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 SqliteSampleBlock.cpp
 

--- a/src/SseMathFuncs.h
+++ b/src/SseMathFuncs.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-   Audacity: A Digital Audio Editor
+   Tenacity
 
    SseMathFuncs.h
 

--- a/src/Tags.cpp
+++ b/src/Tags.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Tags.cpp
 

--- a/src/Tags.h
+++ b/src/Tags.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Tags.h
 

--- a/src/TempDirectory.cpp
+++ b/src/TempDirectory.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  TempDirectory.cpp
  

--- a/src/TempDirectory.h
+++ b/src/TempDirectory.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  TempDirectory.h
  

--- a/src/Theme.cpp
+++ b/src/Theme.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Theme.cpp
 

--- a/src/Theme.h
+++ b/src/Theme.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Theme.h
 

--- a/src/TimeDialog.cpp
+++ b/src/TimeDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TimeDialog.cpp
 

--- a/src/TimeDialog.h
+++ b/src/TimeDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TimeDialog.h
 

--- a/src/TimeTrack.cpp
+++ b/src/TimeTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TimeTrack.cpp
 

--- a/src/TimeTrack.h
+++ b/src/TimeTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TimeTrack.h
 

--- a/src/TimerRecordDialog.cpp
+++ b/src/TimerRecordDialog.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TimerRecordDialog.cpp
 

--- a/src/TimerRecordDialog.h
+++ b/src/TimerRecordDialog.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TimerRecordDialog.h
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   Track.cpp
 

--- a/src/Track.h
+++ b/src/Track.h
@@ -1,6 +1,6 @@
 /*!********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   @file Track.h
   @brief declares abstract base class Track, TrackList, and iterators over TrackList

--- a/src/TrackArtist.cpp
+++ b/src/TrackArtist.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackArtist.cpp
 

--- a/src/TrackArtist.h
+++ b/src/TrackArtist.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackArtist.h
 

--- a/src/TrackInfo.cpp
+++ b/src/TrackInfo.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackInfo.cpp
 

--- a/src/TrackInfo.h
+++ b/src/TrackInfo.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackInfo.h
 

--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackPanel.cpp
 

--- a/src/TrackPanel.h
+++ b/src/TrackPanel.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackPanel.h
 

--- a/src/TrackPanelAx.cpp
+++ b/src/TrackPanelAx.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackPanelAx.cpp
 

--- a/src/TrackPanelAx.h
+++ b/src/TrackPanelAx.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackPanelAx.h
 

--- a/src/TrackPanelCell.cpp
+++ b/src/TrackPanelCell.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  TrackPanelCell.cpp
  

--- a/src/TrackPanelCell.h
+++ b/src/TrackPanelCell.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackPanelCell.h
 

--- a/src/TrackPanelDrawable.cpp
+++ b/src/TrackPanelDrawable.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  TrackPanelDrawable.cpp
  

--- a/src/TrackPanelDrawable.h
+++ b/src/TrackPanelDrawable.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackPanelDrawable.h
 

--- a/src/TrackPanelDrawingContext.h
+++ b/src/TrackPanelDrawingContext.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Tenacity
 
  TrackPanelDrawingContext.h
 

--- a/src/TrackPanelListener.h
+++ b/src/TrackPanelListener.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   TrackPanelListener.h
 

--- a/src/TrackPanelMouseEvent.h
+++ b/src/TrackPanelMouseEvent.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackPanelMouseEvent.h
 

--- a/src/TrackPanelResizeHandle.cpp
+++ b/src/TrackPanelResizeHandle.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackPanelResizeHandle.cpp
 

--- a/src/TrackPanelResizeHandle.h
+++ b/src/TrackPanelResizeHandle.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackPanelResizeHandle.h
 

--- a/src/TrackPanelResizerCell.cpp
+++ b/src/TrackPanelResizerCell.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 TrackPanelResizeHandle.cpp
 

--- a/src/TrackPanelResizerCell.h
+++ b/src/TrackPanelResizerCell.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
- Audacity: A Digital Audio Editor
+ Tenacity
 
  TrackPanelResizerCell.h
 

--- a/src/TrackUtilities.cpp
+++ b/src/TrackUtilities.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  TrackUtilities.cpp
  

--- a/src/TrackUtilities.h
+++ b/src/TrackUtilities.h
@@ -1,6 +1,6 @@
 /**********************************************************************
  
- Audacity: A Digital Audio Editor
+ Tenacity
  
  TrackUtilities.h
  

--- a/src/UIHandle.cpp
+++ b/src/UIHandle.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 UIHandle.cpp
 

--- a/src/UIHandle.h
+++ b/src/UIHandle.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 UIHandle.h
 

--- a/src/UndoManager.cpp
+++ b/src/UndoManager.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   UndoManager.cpp
 

--- a/src/UndoManager.h
+++ b/src/UndoManager.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   UndoManager.h
 

--- a/src/ViewInfo.cpp
+++ b/src/ViewInfo.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 ViewInfo.cpp
 

--- a/src/ViewInfo.h
+++ b/src/ViewInfo.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ViewInfo.h
 

--- a/src/VoiceKey.cpp
+++ b/src/VoiceKey.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   VoiceKey.cpp
 

--- a/src/WaveClip.cpp
+++ b/src/WaveClip.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   WaveClip.cpp
 

--- a/src/WaveClip.h
+++ b/src/WaveClip.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   WaveClip.h
 

--- a/src/WaveTrack.cpp
+++ b/src/WaveTrack.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   WaveTrack.cpp
 

--- a/src/WaveTrack.h
+++ b/src/WaveTrack.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   WaveTrack.h
 

--- a/src/WaveTrackLocation.h
+++ b/src/WaveTrackLocation.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 WaveTrackLocation.h
 

--- a/src/ZoomInfo.cpp
+++ b/src/ZoomInfo.cpp
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ZoomInfo.cpp
 

--- a/src/ZoomInfo.h
+++ b/src/ZoomInfo.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-  Audacity: A Digital Audio Editor
+  Tenacity
 
   ZoomInfo.h
 

--- a/src/wxFileNameWrapper.h
+++ b/src/wxFileNameWrapper.h
@@ -1,6 +1,6 @@
 /**********************************************************************
 
-Audacity: A Digital Audio Editor
+Tenacity
 
 wxFileNameWrapper.h
 


### PR DESCRIPTION
List of commands that were executed in the `src directory`:
* sed -i 's/Audacity: A Digital Audio Editor/Tenacity/g' *.h
* sed -i 's/Audacity: A Digital Audio Editor/Tenacity/g' *.cpp

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required