### PR TITLE
Fix wording in 'Building using system libraries'

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -156,8 +156,9 @@ You can use `cmake -LH` to get a list of the options available (or use CMake GUI
 
 On Linux it is possible to build Tenacity using (almost) only the libraries provided by the package manager. Please, see the list of required libraries [here](linux/required_libraries.md).
 
+Follow the steps from [Linux & Other OS](#linux--other-os) section but run CMake with the following arguments:
+
 ```
-$ mkdir build && cd build
 $ cmake -G "Unix Makefiles" \
         -Duse_ffmpeg=loaded \
         -Dlib_preference=system \


### PR DESCRIPTION
Resolves: https://matrix.to/#/!TziQyrZDEYElCYzJeZ:semisol.dev/$86ayhGYkaTA8i2zJsNkE8GklPtX7EnSnCn83YhUyWTg?via=semisol.dev&via=matrix.org&via=kde.org

Make it clear that running CMake to build using system libraries is not enough and running make is necessary too.

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine (does not apply)
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required