### PR TITLE
Rebranding: Change program name, data directory paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,7 @@ lib-src/soundtouch/include/soundtouch_config.h
 lib-src/twolame/doc/html/Doxyfile
 lib-src/twolame/libtwolame/config.h
 locale/POTFILES
-src/audacity.desktop
+src/tenacity.desktop
 src/RevisionIdent.h
 src/configunix.h
 src/configwin.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,9 +442,9 @@ endif()
 
 # Define Audacity's name
 if( CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
-   set( AUDACITY_NAME "Audacity" )
+   set( AUDACITY_NAME "Tenacity" )
 else()
-   set( AUDACITY_NAME "audacity" )
+   set( AUDACITY_NAME "tenacity" )
 endif()
 
 # Create short and full version strings

--- a/help/audacity.appdata.xml
+++ b/help/audacity.appdata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
   <id>org.audacityteam.Audacity</id>
-  <launchable type="desktop-id">audacity.desktop</launchable>
+  <launchable type="desktop-id">tenacity.deskto</launchable>
   <project_license>GPL-2.0 and CC-BY-3.0</project_license>
   <metadata_license>CC0-1.0</metadata_license>
   <name>Audacity</name>

--- a/linux/create_appimage.sh
+++ b/linux/create_appimage.sh
@@ -79,7 +79,7 @@ linuxdeploy --list-plugins
 #============================================================================
 
 ln -sf --no-dereference . "${appdir}/usr"
-ln -sf share/applications/audacity.desktop "${appdir}/audacity.desktop"
+ln -sf share/applications/tenacity.desktop "${appdir}/tenacity.desktop"
 ln -sf share/icons/hicolor/scalable/apps/audacity.svg "${appdir}/audacity.svg"
 ln -sf share/icons/hicolor/scalable/apps/audacity.svg "${appdir}/.DirIcon"
 

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1149,15 +1149,15 @@ bool AudacityApp::OnInit()
       wxT(INSTALL_PREFIX), wxT(AUDACITY_NAME)),
       audacityPathList);
 #else //AUDACITY_NAME
-   FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/.audacity-files"),
+   FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/.tenacity-files"),
       home),
       audacityPathList)
    FileNames::AddUniquePathToPathList(FileNames::ModulesDir(),
       audacityPathList);
-   FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/share/audacity"),
+   FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/share/tenacity"),
       wxT(INSTALL_PREFIX)),
       audacityPathList);
-   FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/share/doc/audacity"),
+   FileNames::AddUniquePathToPathList(wxString::Format(wxT("%s/share/doc/tenacity"),
       wxT(INSTALL_PREFIX)),
       audacityPathList);
 #endif //AUDACITY_NAME

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1279,7 +1279,7 @@ else()
    endif()
 
    # Create the desktop file
-   configure_file( audacity.desktop.in ${_INTDIR}/audacity.desktop )
+   configure_file( tenacity.desktop.in ${_INTDIR}/tenacity.desktop )
 
    # Copy the required wxWidgets libs into the bundle
    add_custom_command(
@@ -1361,7 +1361,7 @@ else()
                DESTINATION "${_LIBDIR}"
                USE_SOURCE_PERMISSIONS
                FILES_MATCHING PATTERN "*.so*" )
-      install( FILES "${_INTDIR}/audacity.desktop"
+      install( FILES "${_INTDIR}/tenacity.desktop"
                DESTINATION "${_DATADIR}/applications" )
       install( FILES "${topdir}/LICENSE.txt" "${topdir}/README.md"
                DESTINATION "${_DATADIR}/doc/${AUDACITY_NAME}" )

--- a/src/tenacity.desktop.in
+++ b/src/tenacity.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Name=Audacity
+Name=Tenacity
 GenericName=Sound Editor
 GenericName[ar]=محرر أصوات
 GenericName[ca]=Editor d'àudio


### PR DESCRIPTION
Additional notes:
- The output path for builds on Linux is `./bin/Debug/tenacity`. Program opens normally, this change is mostly cosmetic, part of our rebranding effort and doesn't affect functionality.
- I haven't checked if this could break something in the CI, let's be sure of that before we merge.
- I'd preferably change the variable `AUDACITY_NAME` as well, but I'm not sure if that could make things too "incompatible" with Audacity's upstream source for our liking.

---

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required