### PR TITLE
Fix `RevisionIdent.h` generation (Issue #272)

### DIFF
--- a/cmake-proxies/cmake-modules/Version.cmake
+++ b/cmake-proxies/cmake-modules/Version.cmake
@@ -4,7 +4,7 @@
 
 execute_process(
    COMMAND
-      ${GIT} show -s "--format=#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n"
+      ${GIT} show -s "--format=#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" --no-notes --no-show-signature
    OUTPUT_FILE
       ${_PRVDIR}/RevisionIdent.h.in
    OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
Resolves: #272

Modify `cmake-proxies/cmake-modules/Version.cmake` to use `git show` properly.

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\