### PR TITLE
Increase default refresh rate in Meter widget

### DIFF
--- a/src/widgets/Meter.cpp
+++ b/src/widgets/Meter.cpp
@@ -7,7 +7,7 @@
   Dominic Mazzoni
   Vaughan Johnson
 
-  2004.06.25 refresh rate limited to 30mS, by ChackoN
+  Refresh rate limited to 60Hz
 
 *******************************************************************//**
 
@@ -414,7 +414,7 @@ void MeterPanel::UpdatePrefs()
 
    mMeterRefreshRate =
       std::max(MIN_REFRESH_RATE, std::min(MAX_REFRESH_RATE,
-         gPrefs->Read(Key(wxT("RefreshRate")), 30)));
+         gPrefs->Read(Key(wxT("RefreshRate")), 60)));
    mGradient = gPrefs->Read(Key(wxT("Bars")), wxT("Gradient")) == wxT("Gradient");
    mDB = gPrefs->Read(Key(wxT("Type")), wxT("dB")) == wxT("dB");
    mMeterDisabled = gPrefs->Read(Key(wxT("Disabled")), (long)0);


### PR DESCRIPTION
I'm assuming that most workstations should be equipped to handle this.

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required