### PR TITLE
GH Actions: explicitly specify clang as compiler on macOS

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -41,6 +41,8 @@ jobs:
         - name: macOS_Intel
           os: macos-latest
           arch: Intel # as reported by Apple menu > About This Mac
+          cc: clang
+          cxx: clang++
           generator: Unix Makefiles
           compiler_cache: ccache
           compiler_cache_path: ~/Library/Caches/ccache

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -41,8 +41,8 @@ jobs:
         - name: macOS_Intel
           os: macos-latest
           arch: Intel # as reported by Apple menu > About This Mac
-          cc: clang
-          cxx: clang++
+          #cc: clang
+          #cxx: clang++
           generator: Unix Makefiles
           compiler_cache: ccache
           compiler_cache_path: ~/Library/Caches/ccache
@@ -124,8 +124,8 @@ jobs:
         APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         APPLE_NOTARIZATION_USER_NAME: ${{ secrets.APPLE_NOTARIZATION_USER_NAME }}
         APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-        CC: ${{ matrix.config.cc }}
-        CXX: ${{ matrix.config.cxx }}
+        #CC: ${{ matrix.config.cc }}
+        #CXX: ${{ matrix.config.cxx }}
       run: |
         exec bash "scripts/ci/configure.sh"
 

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -43,7 +43,7 @@ jobs:
           arch: Intel # as reported by Apple menu > About This Mac
           #cc: clang
           #cxx: clang++
-          generator: Unix Makefiles
+          generator: Xcode
           compiler_cache: ccache
           compiler_cache_path: ~/Library/Caches/ccache
 


### PR DESCRIPTION
Signed-off-by: Be <be@mixxx.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Trying to fix build of mpg123 in Conan

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required