### PR TITLE
Fix: Edit cursor coloring not being applied

### DIFF
--- a/src/AColor.cpp
+++ b/src/AColor.cpp
@@ -467,7 +467,7 @@ wxColour CursorColour( )
 
    // Pen colour is fine, if there is plenty of contrast.
    if( d  > 200 )
-      return clrCursorPen;
+      return theTheme.Colour( clrCursorPen );
 
    // otherwise return same colour as a selection.
    return theTheme.Colour( clrSelected );

--- a/src/tracks/ui/EditCursorOverlay.cpp
+++ b/src/tracks/ui/EditCursorOverlay.cpp
@@ -121,7 +121,7 @@ void EditCursorOverlay::Draw(OverlayPanel &panel, wxDC &dc)
    }
    else if (auto ruler = dynamic_cast<AdornedRulerPanel*>(&panel)) {
       wxASSERT(!mIsMaster);
-      dc.SetPen(*wxBLACK_PEN);
+      AColor::CursorColor(&dc);
       // AColor::Line includes both endpoints so use GetBottom()
       auto rect = ruler->GetInnerRect();
       AColor::Line(dc, mLastCursorX, rect.GetTop(), mLastCursorX, rect.GetBottom());


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

The specified color for the edit cursor is supposed to be returned when there's enough contrast, otherwise it returns the selection color as a fallback.
The specified color never got returned, and instead it returned null.
Also the part of the cursor in the ruler was hard coded black.
This prevents proper theming and accessibility.

This PR corrects the coloring of the edit cursor and matches the ruler part with the track part.


<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required