### PR TITLE
Fix typo in macos building instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -113,7 +113,7 @@ Alternatively, you can use **CLion**. If you chose to do so, open the directory 
 At the moment we only support **x86_64** builds. It is possible to build using AppleSilicon hardware but **mad** and **id3tag** should be disabled:
 
 ```
-cmake -GXCode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
+cmake -GXcode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
 ```
 
 ## Linux & Other OS


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

This fixes a typo in the building instructions for macOS:
The CMake generator is called 'Xcode' with a lowercase c (like a few lines above), not 'XCode'.
The command would fail unless this was changed.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required