### PR TITLE
NoteTrackShifter: Fix build without USE_MIDI

### DIFF
--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackShifter.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackShifter.cpp
@@ -3,6 +3,7 @@
  @brief headerless file injects method definitions for time shifting of NoteTrack
  */
 
+#ifdef USE_MIDI
 #include "../../../ui/TimeShiftHandle.h"
 #include "../../../../NoteTrack.h"
 #include "../../../../ViewInfo.h"
@@ -60,3 +61,4 @@ template<> template<> auto MakeNoteTrackShifter::Implementation() -> Function {
    };
 }
 static MakeNoteTrackShifter registerMakeNoteTrackShifter;
+#endif


### PR DESCRIPTION
Try to keep PortMIDI/PortSMF optional by wrapping it within USE_MIDI
check like NoteTrack class itself is.

This allows me to build tenacity without PortSMF after small local changes to remove the requirement of PortMIDI and co on top of #228, but looks like a simple useful change that could be included for now in terms of correctness and uniformity with NoteTrack.cpp itself.

I have not tested builds WITH USE_MIDI enabled and thus with PortSMF, as current state of master doesn't work for me with conan and without that I don't have a system PortSMF available to successfully compile a bundled version.


<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required