### PR TITLE
Restore compatibility with wxWidgets-3.0

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -5,8 +5,12 @@
 ### Linux
 
 Most distributions do not package all of Tenacity's dependencies (yet).
-wxWidgets 3.1 is required for building Tenacity but many distributions only
-package wxWidgets 3.0. [PortMidi](https://github.com/mixxxdj/portmidi) and
+wxWidgets 3.1 is suggested for building Tenacity but many distributions only
+package wxWidgets 3.0. When 3.0 is used instead of 3.1, the main user visible
+known drawback is that a few user interface texts will not be localized, and
+the effects of not having various wxWidgets bug fixes that have not been
+backported to the stable 3.0 series.
+[PortMidi](https://github.com/mixxxdj/portmidi) and
 [PortSMF](https://github.com/tenacityteam/portsmf) are required for MIDI support
 but some distributions do not package PortSMF (Tenacity can still build without
 MIDI support). [libsbsms](https://github.com/claytonotey/libsbsms) is an
@@ -64,7 +68,7 @@ to the CMake configuration step.
 package called `libjack0`, you may need to install `libjack-jack2-dev` instead
 of `libjack-dev`.
 
-- wxWidgets 3.1 is required but not packaged in Debian or Ubuntu. Refer
+- wxWidgets 3.1 is suggested but not packaged in Debian or Ubuntu. Refer
 to the
 [wxWidgets documentation](https://docs.wxwidgets.org/3.1/overview_cmake.html)
 for how to install it from source code, or see the [previous section](#wxwidgets-from-source). The above package list
@@ -76,6 +80,12 @@ example, if you installed wxWidgets to /home/user/local:
 
 ```
 export WX_CONFIG=/home/user/local/bin/wx-config
+```
+
+- Alternatively, you may skip installing wxWidgets 3.1 and use 3.0 instead:
+
+```
+sudo apt-get install libwxgtk3.0-dev
 ```
 
 #### Fedora
@@ -114,7 +124,8 @@ export WX_CONFIG=/home/user/local/bin/wx-config
 
 #### Arch
 
-Install `wxgtk3-dev-light` with your AUR helper of choice, for example:
+To use wxWidgets 3.1, install `wxgtk3-dev-light` with your AUR helper of
+choice, for example:
 
 ```
 paru -S wxgtk3-dev-light
@@ -126,6 +137,9 @@ this AUR package:
 ```
 export WX_CONFIG=/usr/bin/wx-config-gtk3-3.1
 ```
+
+Alternatively, install `wxgtk3` with pacman to use wxWidgets 3.0, and set
+`WX_CONFIG=/usr/bin/wx-config-gtk3`.
 
 Install the rest of the build dependencies from the main Arch repository:
 
@@ -144,7 +158,7 @@ community repository:
 sudo apk add cmake samurai lame-dev libsndfile-dev soxr-dev sqlite-dev portaudio-dev portmidi-dev libid3tag-dev soundtouch-dev libmad-dev ffmpeg-dev
 ```
 
-wxWidgets 3.1 is required but not packaged in Alpine Linux. Refer to the
+wxWidgets 3.1 is suggested but not packaged in Alpine Linux. Refer to the
 [wxWidgets documentation](https://github.com/wxWidgets/wxWidgets/blob/master/docs/gtk/install.md)
 for how to install it from source code, and make sure to set
 `--disable-xlocale` in the configuration.
@@ -154,6 +168,9 @@ To install wxWidgets' dependencies:
 ```
 sudo apk add gtk+3.0-dev zlib-dev libpng-dev tiff-dev libjpeg-turbo-dev expat-dev
 ```
+
+Alternatively, install `wxgtk3-dev` with apk to use wxWidgets 3.0, and set
+`WX_CONFIG=/usr/bin/wx-config-gtk3`.
 
 TODO: add portsmf and libsbsms to this package list when aports are accepted.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -801,11 +801,19 @@ if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
 endif()
 
 if( NOT WIN32 )
-  set( wxWidgets_CONFIG_OPTIONS --version=3.1 )
+  # wxWidgets 3.1 can be explicitly selected if both 3.0 and 3.1 are installed by setting
+  # the WX_CONFIG environment variable to path of the wx-config script for 3.1.
   find_package(
-    wxWidgets 3.1
+    wxWidgets 3.0
     COMPONENTS adv base core html qa xml net
   )
+
+  if(NOT wxWidgets_FOUND)
+    message(FATAL_ERROR "wxWidgets NOT found. "
+      "Install wxWidgets and its development headers and try again. "
+      "If wxWidgets is installed, set the WX_CONFIG environment variable to the path of the wx-config script.")
+  endif()
+
   include( ${wxWidgets_USE_FILE} )
   # The FindwxWidgets.cmake module does not create an IMPORT target, so hack one together. This makes it easy to add the compile definitions
   # to the lib-strings and lib-strings-utils targets.

--- a/libraries/lib-strings/TranslatableString.cpp
+++ b/libraries/lib-strings/TranslatableString.cpp
@@ -97,7 +97,12 @@ wxString TranslatableString::DoSubstitute( const Formatter &formatter,
    return formatter
       ? formatter( format, debug ? Request::DebugFormat : Request::Format )
       : // come here for most translatable strings, which have no formatting
-         ( debug ? format : wxGetTranslation( format, wxString{}, context ) );
+         ( debug ? format : wxGetTranslation(
+               format
+#if HAS_I18N_CONTEXTS
+               , wxString{}, context
+#endif
+            ) );
 }
 
 wxString TranslatableString::DoChooseFormat(

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -1049,7 +1049,9 @@ bool AudacityApp::OnInit() {
     wxFileSystem::AddHandler(safenew wxZipFSHandler);
 
     // encouraged by wxwidgets
+#if wxCHECK_VERSION(3, 1, 1)
     wxStandardPaths::Get().SetFileLayout(wxStandardPaths::FileLayout::FileLayout_XDG);
+#endif
 
     //
     // Paths: set search path and temp dir path

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -47,6 +47,10 @@ used throughout Audacity into this one place.
 #include <windows.h>
 #endif
 
+#if defined(__WXGTK__) && !wxCHECK_VERSION(3, 1, 1)
+#include <glib.h>
+#endif
+
 static wxString gConfigDir;
 static wxString gDataDir;
 
@@ -246,6 +250,8 @@ FilePath FileNames::ConfigDir()
          // Use OS-provided user data dir folder
 #if defined(__WXMSW__)
          wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("\\Tenacity"));
+#elif defined(__WXGTK__) && !wxCHECK_VERSION(3, 1, 1)
+         wxString configDir = wxString::Format(wxT("%s/tenacity"), g_get_user_config_dir());
 #else
          wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("/tenacity"));
 #endif

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -244,7 +244,7 @@ FilePath FileNames::ConfigDir()
          gConfigDir = portablePrefsPath.GetFullPath();
       } else {
          // Use OS-provided user data dir folder
-#if defined(__WSMSW__)
+#if defined(__WXMSW__)
          wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("\\Tenacity"));
 #else
          wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("/tenacity"));


### PR DESCRIPTION
This restores compatibility with wxWidgets-3.0, but has the following things unhandled:

* ~~AutoRecoveryDialog changes split out into #569 too could use more testing and behaviour comparison with old stuff, etc.~~
* ~~XDG file layout support doesn't exist in 3.0 yet and needs separate handling now. We can just use g_get_user_config_dir and g_get_user_cache_dir and such directly if wxGTK and wx3.0 until we decide to minimum depend on an upcoming wx3.2 release. Current version in here to get it to build just removes the XDG layout call, which makes it use $HOME/tenacity instead of the correct thing.~~
* ~~Figuring out problem with my initial TranslatableString compatibility (mentioned in self-review of #514)~~ Made to ignore the context with 3.0, leading to untranslated strings, but better than not being able to compile at all, and there were already other cases in the code that didn't have 3.0 compat removed from yet. I think this is good enough for now, in the hopes that 3.2 will actually happen this year still.
* ~~FileConfig change just makes the issue probably happen that the wx3.1 specific API call intends to solve, which is just removed in case of building against 3.0. It might be possible to solve this universally without this flushing hack, as the old comments allude to, but not sure it's worth it, as there are more important things to do and the regression doesn't seem too bad - plus 3.2 will hopefully be out by end of year anyhow. Though I do think relying on this DisableAutoSave behaviour is problematic for 3.2 too.~~ (merged)
* ~~I'm unsure if I got the hashing thing right, with the wxWidgets introduced one being slightly different than what I put in as something audacity had before to make this work with 3.0.~~ (merged)
* ~~This is not compile tested against master, as I don't have working conan build, so I worked on top of #228 with the wx dep reduced on top of that locally, to get it to accept my system wxGTK-3.0.5~~
* ~~Relatedly it still misses a commit to reduce the minimum requirement in the build system, with things very much in flux re #228 and other pending things.~~

All that said: 
![Kuvatõmmis 2021-07-18 12-46-21](https://user-images.githubusercontent.com/133723/126065092-e0dfa179-5ef9-461c-a3a8-12eb512a8b4a.png)


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required