### PR TITLE
Re-add translation credits as comment in pt_BR.po

### DIFF
--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -1,3 +1,12 @@
+# Cleber Tavano (2002-2021), com contribuições, atualizações e revisões de
+# Djavan Fagundes (2010), Paulo Castro (2013), Rogênio Belém (2013),
+# Flávio Salgado Moreira (2014), Marcelo Thomaz de Aquino Filho (2014),
+# Victor Westmann (2014-2015), Gutem (2015), Henrique Terto de Souza (2015-2017),
+# Igor Rückert, (2015-2020), Marcos Nakamine, (2015), Pablo do Amaral Ferreira (2015),
+# Thales Alexander Barné Peres (2015), Ciro (2016), J.Nylson (2016),
+# Lourenço Schmid (2016), millemiglia (2016), Rodrigo de Araújo (2016),
+# Diego Medeiros (2016-2017), Thomas De Rocker (2017), Bruno Ramalhete (2019),
+# Aline Furlanetto Viero (2021)
 # Heitor Rocha <heitor@riseup.net>, 2021.
 msgid ""
 msgstr ""


### PR DESCRIPTION
These were accidentally lost in commit 75c93c68d1c910d1471af52225fe2109d52eac4b
because they were initially wrongly added to the “Language-Team” field,
which Weblate overwrites.