### PR TITLE
Correct MacOS CPack configuration

### DIFF
--- a/scripts/ci/macos/repeat_hdiutil.sh
+++ b/scripts/ci/macos/repeat_hdiutil.sh
@@ -8,13 +8,13 @@ max_retry=5
 counter=0
 num_secs_await_retry=1
 
-until /usr/bin/hdiutil ""$*"" -debug; do
+until /usr/bin/hdiutil "$@" -debug; do
    sleep $num_secs_await_retry
    if [[ $counter -eq $max_retry ]]; then
         echo "CPack failed despite retry attempts!"
         exit 1
    else
-        echo "Trying CPack hdiutil call again. Try #$counter"
+        echo "Trying CPack hdiutil call again. Retry attempt #$counter"
         ((counter++))
    fi
 done

--- a/scripts/ci/macos/repeat_hdiutil.sh
+++ b/scripts/ci/macos/repeat_hdiutil.sh
@@ -2,7 +2,7 @@
 
 ((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$0: Error: Please upgrade Bash."; exit 1; }
 
-set -uxo pipefail
+set -uo pipefail
 
 max_retry=5
 counter=0

--- a/scripts/ci/macos/repeat_hdiutil.sh
+++ b/scripts/ci/macos/repeat_hdiutil.sh
@@ -4,11 +4,15 @@
 
 set -uxo pipefail
 
+set +x
+
 max_retry=5
 counter=0
 num_secs_await_retry=1
 
-until /usr/bin/hdiutil "$@" -debug; do
+echo "Trying: " /usr/bin/hdiutil "$@"
+
+until /usr/bin/hdiutil "$@"; do
    sleep $num_secs_await_retry
    if [[ $counter -eq $max_retry ]]; then
         echo "CPack failed despite retry attempts!"

--- a/scripts/ci/macos/repeat_hdiutil.sh
+++ b/scripts/ci/macos/repeat_hdiutil.sh
@@ -4,8 +4,6 @@
 
 set -uxo pipefail
 
-set +x
-
 max_retry=5
 counter=0
 num_secs_await_retry=1

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -12,8 +12,8 @@ else
    # This will break if you move this script to a different directory
    # because this searches for the current script's directory and the
    # path is relative to that absolute path.
-   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${SCRIPT_DIR}/macos/repeat_hdiutil.sh" --verbose
+   export CPACK_SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
+   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${CPACK_SCRIPT_DIR}/macos/repeat_hdiutil.sh" --verbose
 fi
 
 # Remove the temporary directory

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -10,8 +10,7 @@ if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
     SCRIPT_DIR=$(dirname "$0")
-    export CPACK_COMMAND_HDIUTIL="$SCRIPT_DIR/macos/repeat_hdiutil.sh"
-    cpack -C "${AUDACITY_BUILD_TYPE}" --verbose
+    cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${SCRIPT_DIR}/macos/repeat_hdiutil.sh" --verbose
 fi
 
 # Remove the temporary directory

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,7 +9,9 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
-    cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="./macos/repeat_hdiutil.sh" --verbose
+    SCRIPT_DIR=$(dirname "$0")
+    export CPACK_COMMAND_HDIUTIL="$SCRIPT_DIR/macos/repeat_hdiutil.sh"
+    cpack -C "${AUDACITY_BUILD_TYPE}" --verbose
 fi
 
 # Remove the temporary directory

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,8 +9,11 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
-    SCRIPT_DIR=$(dirname "$0")
-    cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${SCRIPT_DIR}/macos/repeat_hdiutil.sh" --verbose
+   # This will break if you move this script to a different directory
+   # because this searches for the current script's directory and the
+   # path is relative to that absolute path.
+   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${SCRIPT_DIR}/macos/repeat_hdiutil.sh" --verbose
 fi
 
 # Remove the temporary directory

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,11 +9,8 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
-   # This will break if you move this script to a different directory
-   # because this searches for the current script's directory and the
-   # path is relative to that absolute path.
-   export CPACK_SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
-   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${CPACK_SCRIPT_DIR}/macos/repeat_hdiutil.sh" --verbose
+   # GITHUB_WORKSPACE is set by the checkout action in the action workflow configuration
+   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${GITHUB_WORKSPACE}/scripts/ci/macos/repeat_hdiutil.sh" --verbose
 fi
 
 # Remove the temporary directory

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -10,7 +10,9 @@ if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
    # GITHUB_WORKSPACE is set by the checkout action in the action workflow configuration
-   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${GITHUB_WORKSPACE}/scripts/ci/macos/repeat_hdiutil.sh" --verbose
+   export CPACK_COMMAND_HDIUTIL="${GITHUB_WORKSPACE}/scripts/ci/macos/repeat_hdiutil.sh"
+   chmod +x $CPACK_COMMAND_HDIUTIL
+   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${CPACK_COMMAND_HDIUTIL}" --verbose
 fi
 
 # Remove the temporary directory

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,8 +9,7 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
-    export CPACK_COMMAND_HDIUTIL="./macos/repeat_hdiutil.sh"
-    cpack -C "${AUDACITY_BUILD_TYPE}" --verbose
+    cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="./macos/repeat_hdiutil.sh" --verbose
 fi
 
 # Remove the temporary directory


### PR DESCRIPTION
The previous fix was not working because CPack actually wanted a CPack var.
Also, make the `repeat_hdiutil.sh` script more clear about retry counts.

Signed-off-by: Emily Mabrey <emilymabrey93@gmail.com>

Resolves: #218 

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*
