### PR TITLE
Move `XO(...)` outside `#ifdef`

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -47,14 +47,20 @@ hold information about a credit item in the Credits list
 // RevisionIdent contains the REV_TIME and REV_LONG defines from git commit information
 #include "RevisionIdent.h"
 
+//This needs to be outside the #ifdef or it won't end up in the POT file consistently
+static wxString NoDateTimeText = XO("Unknown date and time").Translation();
+
 #ifndef REV_TIME
-#define REV_TIME "unknown date and time"
+#define REV_TIME NoDateTimeText
 #endif
+
+//This needs to be outside the #ifdef or it won't end up in the POT file consistently
+static wxString NoRevisionText = XO("No revision identifier was provided").Translation();
 
 #ifdef REV_LONG
 #define REV_IDENT wxString( "[[https://github.com/tenacityteam/tenacity/commit/" )+ REV_LONG + "|" + wxString( REV_LONG ).Left(6) + "]] of " +  REV_TIME 
 #else
-#define REV_IDENT (XO("No revision identifier was provided").Translation())
+#define REV_IDENT (NoRevisionText)
 #endif
 
 // To substitute into many other translatable strings


### PR DESCRIPTION
Placing `XO` usage inside pre-processor blocks is not consistenly translatable.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*
