### PR TITLE
Draw edit cursor across entire track area

### DIFF
--- a/src/AdornedRulerPanel.cpp
+++ b/src/AdornedRulerPanel.cpp
@@ -339,25 +339,13 @@ void AdornedRulerPanel::QuickPlayIndicatorOverlay::Draw(
         : AColor::Light(&dc, false)
       ;
 
-      // Draw indicator in all visible tracks
-      auto pCellularPanel = dynamic_cast<CellularPanel*>( &panel );
-      if ( !pCellularPanel ) {
-         wxASSERT( false );
-         return;
-      }
-      pCellularPanel
-         ->VisitCells( [&]( const wxRect &rect, TrackPanelCell &cell ) {
-            const auto pTrackView = dynamic_cast<TrackView*>(&cell);
-            if (!pTrackView)
-               return;
-
             // Draw the NEW indicator in its NEW location
-            AColor::Line(dc,
-               mOldQPIndicatorPos,
-               rect.GetTop(),
-               mOldQPIndicatorPos,
-               rect.GetBottom());
-      } );
+      auto rect = panel.GetRect();
+      AColor::Line(dc,
+         mOldQPIndicatorPos,
+         rect.GetTop(),
+         mOldQPIndicatorPos,
+         rect.GetBottom());
    }
 }
 

--- a/src/tracks/ui/EditCursorOverlay.cpp
+++ b/src/tracks/ui/EditCursorOverlay.cpp
@@ -108,15 +108,11 @@ void EditCursorOverlay::Draw(OverlayPanel &panel, wxDC &dc)
          const auto pTrackView = dynamic_cast<TrackView*>(&cell);
          if (!pTrackView)
             return;
-         const auto pTrack = pTrackView->FindTrack();
-         if (pTrack->GetSelected() ||
-             TrackFocus::Get( *mProject ).IsFocused( pTrack.get() ))
-         {
+         auto r = tp->GetRect();
             // AColor::Line includes both endpoints so use GetBottom()
-            AColor::Line(dc, mLastCursorX, rect.GetTop(), mLastCursorX, rect.GetBottom());
+         AColor::Line(dc, mLastCursorX, r.GetTop(), mLastCursorX, r.GetBottom());
             // ^^^ The whole point of this routine.
 
-         }
       } );
    }
    else if (auto ruler = dynamic_cast<AdornedRulerPanel*>(&panel)) {


### PR DESCRIPTION
As long as there are tracks present, draw edit cursor, scrub cursor and
quick play cursor across the entire track area.
Fixes problems introduced by Track Affodances, and also makes the cursors behave like the play and record cursors.

This is customary in most multi track editors.

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #321 

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->


- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required