### PR TITLE
Refactor of About Dialog changes from Pull Request #350

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,6 +15,8 @@ Resolves: *(direct link to the issue)*
 an asterisk (*) after the entry indicates required
 -->
 
+<details>
+<summary>Checklist</summary>
 
 - [ ] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
 - [ ] I made sure the code compiles on my machine
@@ -23,3 +25,5 @@ an asterisk (*) after the entry indicates required
 - [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*
 
 \* indicates required
+
+</details>

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -152,7 +152,7 @@ cmake -GXcode -T buildsystem=1 -Duse_mad="off" -Duse_id3tag=off ../tenacity
    ```
    $ cd bin/Debug
    $ mkdir "Portable Settings"
-   $ ./audacity
+   $ ./tenacity
    ```
 
 At the moment, you are unable to install tenacity system-wide due conflits with libraries. You have to run Step 4 to use Tenacity. We are trying to fix that for the first stable release.

--- a/locale/en.po
+++ b/locale/en.po
@@ -619,119 +619,119 @@ msgstr "GPL License"
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, system administration"
-msgstr "%s, pre-fork system administration"
+msgstr "%s, Audacity system administration"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, co-founder and developer"
-msgstr "%s, pre-fork co-founder and developer"
+msgstr "%s, Audacity co-founder and developer"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer"
-msgstr "%s, pre-fork developer"
+msgstr "%s, Audacity developer"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, developer and support"
-msgstr "%s, pre-fork developer and support"
+msgstr "%s, Audacity developer and support"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support"
-msgstr "%s, pre-fork documentation and support"
+msgstr "%s, Audacity documentation and support"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, QA tester, documentation and support"
-msgstr "%s, pre-fork QA tester, documentation and support"
+msgstr "%s, Audacity QA tester, documentation and support"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, documentation and support, French"
-msgstr "%s, pre-fork documentation and support, French"
+msgstr "%s, Audacity documentation and support, French"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, quality assurance"
-msgstr "%s, pre-fork quality assurance"
+msgstr "%s, Audacity quality assurance"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, accessibility advisor"
-msgstr "%s, pre-fork accessibility advisor"
+msgstr "%s, Audacity accessibility advisor"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphic artist"
-msgstr "%s, pre-fork graphic artist"
+msgstr "%s, Audacity graphic artist"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, composer"
-msgstr "%s, pre-fork composer"
+msgstr "%s, Audacity composer"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, tester"
-msgstr "%s, pre-fork tester"
+msgstr "%s, Audacity tester"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, Nyquist plug-ins"
-msgstr "%s, pre-fork Nyquist plug-ins"
+msgstr "%s, Audacity Nyquist plug-ins"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, web developer"
-msgstr "%s, pre-fork web developer"
+msgstr "%s, Audacity web developer"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, c-format
 msgid "%s, graphics"
-msgstr "%s, pre-fork graphics"
+msgstr "%s, Audacity graphics"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "%s, lead Tenacity developer"
-msgstr "%s, pre-fork web developer"
+msgstr "%s, lead Tenacity developer"
 
 #. i18n-hint: For "About Tenacity..." credits, substituting a person's proper
 #. name
 #: src/AboutDialog.cpp
 #, fuzzy, c-format
 msgid "%s, Tenacity developer"
-msgstr "%s, pre-fork web developer"
+msgstr "%s, Tenacity developer"
 
 #: src/AboutDialog.cpp
 #, c-format
@@ -779,15 +779,15 @@ msgstr "%s includes code from the following projects:"
 
 #: src/AboutDialog.cpp
 msgid "Emeritus:"
-msgstr "Pre-fork Emeritus:"
+msgstr "Audacity Emeritus:"
 
 #: src/AboutDialog.cpp
 msgid "Contributors"
-msgstr "Pre-fork Contributors"
+msgstr "Audacity Contributors"
 
 #: src/AboutDialog.cpp
 msgid "Website and Graphics"
-msgstr "Pre-fork Website and Graphics"
+msgstr "Audacity Website and Graphics"
 
 #. i18n-hint: The translation of "translator_credits" will appear
 #. *  in the credits in the About Audacity window.  Use this to add
@@ -800,11 +800,11 @@ msgstr "translator_credits"
 
 #: src/AboutDialog.cpp
 msgid "Translators"
-msgstr "Pre-fork Translators"
+msgstr "Audacity Translators"
 
 #: src/AboutDialog.cpp
 msgid "Special thanks:"
-msgstr "Pre-fork Special thanks:"
+msgstr "Audacity Special thanks:"
 
 #. i18n-hint: The program's name substitutes for %s
 #: src/AboutDialog.cpp

--- a/scripts/ci/macos/repeat_hdiutil.sh
+++ b/scripts/ci/macos/repeat_hdiutil.sh
@@ -2,19 +2,21 @@
 
 ((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$0: Error: Please upgrade Bash."; exit 1; }
 
-set -uxo pipefail
+set -uo pipefail
 
 max_retry=5
 counter=0
 num_secs_await_retry=1
 
-until /usr/bin/hdiutil ""$*"" -debug; do
+echo "Trying: " /usr/bin/hdiutil "$@"
+
+until /usr/bin/hdiutil "$@"; do
    sleep $num_secs_await_retry
    if [[ $counter -eq $max_retry ]]; then
         echo "CPack failed despite retry attempts!"
         exit 1
    else
-        echo "Trying CPack hdiutil call again. Try #$counter"
+        echo "Trying CPack hdiutil call again. Retry attempt #$counter"
         ((counter++))
    fi
 done

--- a/scripts/ci/package.sh
+++ b/scripts/ci/package.sh
@@ -9,8 +9,10 @@ cd build
 if [[ "${OSTYPE}" == msys* && ${GIT_BRANCH} == release* ]]; then # Windows
     cmake --build . --target innosetup --config "${AUDACITY_BUILD_TYPE}"
 else
-    export CPACK_COMMAND_HDIUTIL="./macos/repeat_hdiutil.sh"
-    cpack -C "${AUDACITY_BUILD_TYPE}" --verbose
+   # GITHUB_WORKSPACE is set by the checkout action in the action workflow configuration
+   export CPACK_COMMAND_HDIUTIL="${GITHUB_WORKSPACE}/scripts/ci/macos/repeat_hdiutil.sh"
+   chmod +x $CPACK_COMMAND_HDIUTIL
+   cpack -C "${AUDACITY_BUILD_TYPE}" -D CPACK_COMMAND_HDIUTIL="${CPACK_COMMAND_HDIUTIL}" --verbose
 fi
 
 # Remove the temporary directory

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -66,7 +66,7 @@ static wxString NoRevisionText = XO("No revision identifier was provided").Trans
 // To substitute into many other translatable strings
 static const auto ProgramName = Verbatim("Tenacity");
 
-static const auto PreforkProgramName = Verbatim("Pre-fork");
+static const auto PreforkProgramName = Verbatim("Audacity");
 
 // ----------------------------------------------------------------------------
 
@@ -123,7 +123,15 @@ void AboutDialog::CreateTenacityTab(ShuttleGui& AboutDialogGUI) {
     GenerateTenacityPageDescription(tenacityPageContent);
 
     GenerateTenacityTeamMembersInfo(tenacityPageContent);
+    GenerateSpecialThanksInfo(tenacityPageContent);
     GenerateTenacityLibsInfo(tenacityPageContent);
+
+    // Pre-form (Audacity) credits
+
+    tenacityPageContent
+        << wxT("<center><h3>")
+        << PreforkProgramName
+        << wxT("</h3></center>");
 
     GeneratePreforkTeamMembersInfo(tenacityPageContent);
     GeneratePreforkEmeritusInfo(tenacityPageContent);
@@ -621,6 +629,13 @@ void AboutDialog::CreateLicenseTab(ShuttleGui& AboutDialogGUI) {
 void AboutDialog::PopulateCreditsList() {
 
     /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
+    const auto tenacity_leadDeveloperFormat = XO("%s, lead Tenacity developer");
+    /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
+    const auto tenacity_developerFormat = XO("%s, Tenacity developer");
+    /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
+    const auto tenacity_contributorFormat = XO("%s, Tenacity contributor");
+
+    /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
     const auto prefork_sysAdminFormat = XO("%s, system administration");
     /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
     const auto prefork_coFounderFormat = XO("%s, co-founder and developer");
@@ -651,14 +666,25 @@ void AboutDialog::PopulateCreditsList() {
     /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
     const auto prefork_graphicsFormat = XO("%s, graphics");
 
-    /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
-    const auto tenacity_leadDeveloperFormat = XO("%s, lead Tenacity developer");
-    /* i18n-hint: For "About Tenacity..." credits, substituting a person's proper name */
-    const auto tenacity_developerFormat = XO("%s, Tenacity developer");
+    // Contributors
 
-    AddCredit(wxT("Emily Mabrey [[https://github.com/emabrey|emabrey]]"), tenacity_leadDeveloperFormat, roleTenacityTeamMember);
-    AddCredit(wxT("Semisol [[https://github.com/Semisol|Semisol]]"), tenacity_developerFormat, roleTenacityTeamMember);
-    AddCredit(wxT("Be [[https://github.com/Be-ing/|Be-ing]]"), tenacity_developerFormat, roleTenacityTeamMember);
+    AddCredit(wxT("abb128 ([[https://github.com/abb128|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("AnotherFoxGuy ([[https://github.com/AnotherFoxGuy|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Ajay Ramachandran ([[https://ajay.app|Website]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Be ([[https://github.com/Be-ing/|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("caughtquick ([[https://caughtquick.tech|Website]]"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Emily \"emabrey\" Mabrey ([[https://github.com/emabrey|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("fossdd ([[https://github.com/fossdd|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("nyanpasu64 ([[https://github.com/nyanpasu64|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Panagiotis \"AlwaysLivid\" Vasilopoulos ([[https://alwayslivid.com|Website]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Rikard \"akleja\" Jansson ([[https://github.com/akleja|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Semisol ([[https://github.com/Semisol|GitHub]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+    AddCredit(wxT("Sol Fisher Romanoff ([[https://solfisher.com|Website]])"), tenacity_contributorFormat, roleTenacityTeamMember);
+
+    // Thanks
+
+    AddCredit(wxT("Drew \"SirCmpwn\" DeVault"), roleThanks);
+    AddCredit(wxT("Filipe \"falkTX\" Coelho"), roleThanks);
 
     // Libraries section
 
@@ -822,12 +848,12 @@ void AboutDialog::GenerateTenacityPageDescription(wxTextOutputStream& tos) {
     #else
         << XO("<h3>")
         << ProgramName
-        << wxT(" ")
-        << wxString(AUDACITY_VERSION_STRING)
-        << wxT("</center></h3>")
+        // << wxT(" ")
+        // << wxString(AUDACITY_VERSION_STRING)
+        << wxT("</h3>")
         /* i18n-hint: The program's name substitutes for %s */
-        << XO("%s the free, open source, cross-platform software for recording and editing sounds.")
-        .Format(ProgramName)
+        << XO("Free, open source, cross-platform audio recorder and editor.")
+        << wxT("</center>")
     #endif
 
         // << wxT("<p><br>")
@@ -837,6 +863,9 @@ void AboutDialog::GenerateTenacityPageDescription(wxTextOutputStream& tos) {
         << wxT("<h3>")
         << XO("Credits")
         << wxT("</h3>")
+        << wxT("<p>")
+        << XO("Please note that names are sorted in alphabetical order, not in order of importance.")
+        << wxT("</p>")
         << wxT("<p>");
 
     // DA: Customisation credit
@@ -853,10 +882,20 @@ void AboutDialog::GenerateTenacityPageDescription(wxTextOutputStream& tos) {
 void AboutDialog::GenerateTenacityTeamMembersInfo(wxTextOutputStream& tos) {
     tos
         << wxT("<p><b>")
+        // To be replaced. Later.
         /* i18n-hint: The program's name substitutes for %s */
-        << XO("%s Team Members").Format(ProgramName)
+        << XO("%s Contributors").Format(ProgramName)
         << wxT("</b><br>")
         << GetCreditsByRole(roleTenacityTeamMember);
+}
+
+void AboutDialog::GenerateSpecialThanksInfo(wxTextOutputStream& tos) {
+
+    tos
+        << wxT("<p><b>")
+        << XO("Special thanks:")
+        << wxT("</b><br>")
+        << GetCreditsByRole(roleThanks);
 }
 
 void AboutDialog::GenerateTenacityLibsInfo(wxTextOutputStream& tos) {

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -29,6 +29,7 @@ hold information about a credit item in the Credits list
 #include <wx/sstream.h>
 #include <wx/txtstrm.h>
 
+#include <BuildInfo.h>
 #include "FileNames.h"
 #include "HelpText.h"
 #include "ShuttleGui.h"
@@ -44,28 +45,10 @@ hold information about a credit item in the Credits list
 #include "../images/AudacityLogoWithName.xpm"
 #endif
 
-// RevisionIdent contains the REV_TIME and REV_LONG defines from git commit information
-#include "RevisionIdent.h"
 
-//This needs to be outside the #ifdef or it won't end up in the POT file consistently
-static wxString NoDateTimeText = XO("Unknown date and time").Translation();
-
-#ifndef REV_TIME
-#define REV_TIME NoDateTimeText
-#endif
-
-//This needs to be outside the #ifdef or it won't end up in the POT file consistently
-static wxString NoRevisionText = XO("No revision identifier was provided").Translation();
-
-#ifdef REV_LONG
-#define REV_IDENT wxString( "[[https://github.com/tenacityteam/tenacity/commit/" )+ REV_LONG + "|" + wxString( REV_LONG ).Left(6) + "]] of " +  REV_TIME 
-#else
-#define REV_IDENT (NoRevisionText)
-#endif
 
 // To substitute into many other translatable strings
 static const auto ProgramName = Verbatim("Tenacity");
-
 static const auto PreforkProgramName = Verbatim("Audacity");
 
 // ----------------------------------------------------------------------------
@@ -110,37 +93,30 @@ void AboutDialog::OnOK(wxCommandEvent& WXUNUSED(event)) {
     EndModal(wxID_OK);
 }
 
-
-#define ABOUT_DIALOG_WIDTH 506
-#define ABOUT_DIALOG_HEIGHT 359
-
 void AboutDialog::CreateTenacityTab(ShuttleGui& AboutDialogGUI) {
     PopulateCreditsList();
 
     wxStringOutputStream tenacityPageGeneratedContent;
     wxTextOutputStream tenacityPageContent(tenacityPageGeneratedContent);   // string to build up list of information in
 
-    GenerateTenacityPageDescription(tenacityPageContent);
+    
+    tenacityPageContent << wxT("<center>");
+        // Tenacity specific credits
+        GenerateTenacityPageDescription(tenacityPageContent);
+        GenerateTenacityTeamMembersInfo(tenacityPageContent);
+        GenerateTenacitySpecialThanksInfo(tenacityPageContent);
+        GenerateTenacityLibsInfo(tenacityPageContent);
 
-    GenerateTenacityTeamMembersInfo(tenacityPageContent);
-    GenerateSpecialThanksInfo(tenacityPageContent);
-    GenerateTenacityLibsInfo(tenacityPageContent);
-
-    // Pre-form (Audacity) credits
-
-    tenacityPageContent
-        << wxT("<center><h3>")
-        << PreforkProgramName
-        << wxT("</h3></center>");
-
-    GeneratePreforkTeamMembersInfo(tenacityPageContent);
-    GeneratePreforkEmeritusInfo(tenacityPageContent);
-    GeneratePreforkContributorInfo(tenacityPageContent);
-    GeneratePreforkTranslatorsInfo(tenacityPageContent);
-    GeneratePreforkGraphicsInfo(tenacityPageContent);
-    GeneratePreforkSpecialThanksInfo(tenacityPageContent);
-    GeneratePreforkWebsiteInfo(tenacityPageContent);
-
+        // Pre-fork (Audacity) credits
+        GeneratePreforkSubheader(tenacityPageContent);
+        GeneratePreforkTeamMembersInfo(tenacityPageContent);
+        GeneratePreforkEmeritusInfo(tenacityPageContent);
+        GeneratePreforkContributorInfo(tenacityPageContent);
+        GeneratePreforkTranslatorsInfo(tenacityPageContent);
+        GeneratePreforkGraphicsInfo(tenacityPageContent);
+        GeneratePreforkSpecialThanksInfo(tenacityPageContent);
+        GeneratePreforkWebsiteInfo(tenacityPageContent);
+        GeneratePreforkTrademarkDisclaimer(tenacityPageContent);
     tenacityPageContent << wxT("</center>");
 
     auto pPage = AboutDialogGUI.StartNotebookPage(ProgramName);
@@ -157,51 +133,15 @@ void AboutDialog::CreateTenacityTab(ShuttleGui& AboutDialogGUI) {
         AboutDialogGUI.Prop(MINIMUM_PROPORTION).AddWindow(AboutDialog::icon);
     }
 
-    HtmlWindow* html = safenew LinkingHtmlWindow(AboutDialogGUI.GetParent(), -1,
+    HtmlWindow* html = safenew LinkingHtmlWindow(AboutDialogGUI.GetParent(), wxID_ANY,
                                                  wxDefaultPosition,
-                                                 wxSize(ABOUT_DIALOG_WIDTH, ABOUT_DIALOG_HEIGHT),
+                                                 ABOUT_DIALOG_DEFAULT_SIZE,
                                                  wxHW_SCROLLBAR_AUTO | wxSUNKEN_BORDER);
     html->SetPage(FormatHtmlText(tenacityPageGeneratedContent.GetString()));
 
     AboutDialogGUI.Prop(GROWING_PROPORTION).Position(wxEXPAND).Focus().AddWindow(html);
     AboutDialogGUI.EndVerticalLay();
     AboutDialogGUI.EndNotebookPage();
-}
-
-static const wxString getCompilerVersion() {
-#if defined(_MSC_FULL_VER)
-    return wxString::Format(wxT("MSVC %02d.%02d.%05d.%02d"), _MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 100000, _MSC_BUILD);
-#elif defined(__GNUC_PATCHLEVEL__) && defined(__MINGW32__)
-    return wxT("MinGW ") wxMAKE_VERSION_DOT_STRING_T(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
-#elif defined(__GNUC_PATCHLEVEL__)
-    return wxT("GCC ") wxMAKE_VERSION_DOT_STRING_T(__GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__);
-#elif defined(__clang_version__)
-    return wxT("clang ") __clang_version__;
-#else
-    return wxt("Unknown!!!");
-#endif
-}
-
-static const TranslatableString getBuildType() {
-
-    auto buildType = Verbatim("Unknown Build Type!!!");
-
-#ifdef _DEBUG
-    buildType = XO("Debug build (debug level %d)").Format(wxDEBUG_LEVEL);
-#else
-    buildType = XO("Release build (debug level %d)").Format(wxDEBUG_LEVEL);
-#endif
-
-    if ((sizeof(void*) == 8)) {
-        buildType = XO("%s, 64 bits").Format(buildType);
-    }
-
-    // Remove this once the transition to CMake is complete
-#ifdef CMAKE
-    buildType = Verbatim("CMake %s").Format(buildType);
-#endif
-
-    return buildType;
 }
 
 /** \brief: Fills out the "Information" tab of the preferences dialogue
@@ -237,9 +177,9 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
         << XO("The Build")
         << wxT("</h3>\n<table>"); // start build info table
 
-    AddBuildInfoRow(&informationStr, XO("Commit Id:"), REV_IDENT);
-    AddBuildInfoRow(&informationStr, XO("Build type:"), getBuildType().Translation());
-    AddBuildInfoRow(&informationStr, XO("Compiler:"), getCompilerVersion());
+    AddBuildInfoRow(&informationStr, XO("Commit Id:"), BuildInfo::getRevisionIdentifier());
+    AddBuildInfoRow(&informationStr, XO("Build type:"), BuildInfo::getBuildType());
+    AddBuildInfoRow(&informationStr, XO("Compiler:"), BuildInfo::getCompilerVersionString());
 
     // Install prefix
 #ifdef __WXGTK__
@@ -250,21 +190,6 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
     // Location of settings
     AddBuildInfoRow(&informationStr, XO("Settings folder:"), FileNames::DataDir());
 
-    /*
-    informationStr << wxT("</table>\n"); // end of build info table
-    informationStr
-        << wxT("<h3>")
-        /* i18n-hint: Libraries that are essential to Tenacity *//*
-        << XO("Core Libraries")
-        << wxT("</h3>\n<table>");  // start table of core libraries
-
-    AddBuildInfoRow(&informationStr, wxT("wxWidgets"), XO("Cross-platform GUI library"), Verbatim(wxVERSION_NUM_DOT_STRING_T));
-    AddBuildInfoRow(&informationStr, wxT("PortAudio"), XO("Audio playback and recording"), Verbatim(wxT("v19")));
-    AddBuildInfoRow(&informationStr, wxT("libsoxr"), XO("Sample rate conversion"), enabled);
-
-    informationStr << wxT("</table>\n"); // end table of core libraries
-    */
-
     informationStr
         << wxT("<h3>")
         << XO("File Format Support")
@@ -273,6 +198,9 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
     informationStr
         << wxT("<table>");   // start table of file formats supported
 
+    AddBuildInfoRow(&informationStr, wxT("wxWidgets"), XO("Cross-platform GUI library"), Verbatim(wxVERSION_NUM_DOT_STRING_T));
+    AddBuildInfoRow(&informationStr, wxT("PortAudio"), XO("Audio playback and recording"), Verbatim(wxT("v19")));
+    AddBuildInfoRow(&informationStr, wxT("libsoxr"), XO("Sample rate conversion"), enabled);
     AddBuildInfoRow(&informationStr, wxT("libmad"), XO("MP3 Importing"), USE_LIBMAD ? enabled : disabled);
     /* i18n-hint: Ogg is the container format. Vorbis is the compression codec. Both are proper nouns and shouldn't be translated */
     AddBuildInfoRow(&informationStr, wxT("libvorbis"), XO("Ogg Vorbis Import and Export"), USE_LIBVORBIS ? enabled : disabled);
@@ -683,8 +611,8 @@ void AboutDialog::PopulateCreditsList() {
 
     // Thanks
 
-    AddCredit(wxT("Drew \"SirCmpwn\" DeVault"), roleThanks);
-    AddCredit(wxT("Filipe \"falkTX\" Coelho"), roleThanks);
+    AddCredit(wxT("Drew \"SirCmpwn\" DeVault"), roleTenacityThanks);
+    AddCredit(wxT("Filipe \"falkTX\" Coelho"), roleTenacityThanks);
 
     // Libraries section
 
@@ -834,16 +762,14 @@ wxImage AboutDialog::GenerateTenacityLogoRescaledImage(const float fScale) {
 
 void AboutDialog::GenerateTenacityPageDescription(wxTextOutputStream& tos) {
     tos
-        << wxT("<center>")
         // DA: Description and provenance in About box
     #ifdef EXPERIMENTAL_DA
     #undef _
     #define _(s) wxGetTranslation((s))
         << wxT("<h3>DarkTenacity ")
         << wxString(AUDACITY_VERSION_STRING)
-        << wxT("</center></h3>")
-        << wxT("Customised version of the Tenacity free, open source, cross-platform software ")
-        << wxT("for recording and editing sounds.")
+        << wxT("</h3>")
+        << wxT("Customised version of the free, open source, cross-platform audio recorder and editor Tenacity.")
 
     #else
         << XO("<h3>")
@@ -853,7 +779,6 @@ void AboutDialog::GenerateTenacityPageDescription(wxTextOutputStream& tos) {
         << wxT("</h3>")
         /* i18n-hint: The program's name substitutes for %s */
         << XO("Free, open source, cross-platform audio recorder and editor.")
-        << wxT("</center>")
     #endif
 
         // << wxT("<p><br>")
@@ -889,13 +814,13 @@ void AboutDialog::GenerateTenacityTeamMembersInfo(wxTextOutputStream& tos) {
         << GetCreditsByRole(roleTenacityTeamMember);
 }
 
-void AboutDialog::GenerateSpecialThanksInfo(wxTextOutputStream& tos) {
+void AboutDialog::GenerateTenacitySpecialThanksInfo(wxTextOutputStream& tos) {
 
     tos
         << wxT("<p><b>")
-        << XO("Special thanks:")
+        << XO("Tenacity Special thanks:")
         << wxT("</b><br>")
-        << GetCreditsByRole(roleThanks);
+        << GetCreditsByRole(roleTenacityThanks);
 }
 
 void AboutDialog::GenerateTenacityLibsInfo(wxTextOutputStream& tos) {
@@ -910,7 +835,15 @@ void AboutDialog::GenerateTenacityLibsInfo(wxTextOutputStream& tos) {
         << GetCreditsByRole(roleLibrary);
 }
 
-void AboutDialog::GeneratePreforkTeamMembersInfo(wxTextOutputStream& tos) {
+void AboutDialog::GeneratePreforkSubheader(wxTextOutputStream &tos) {
+    tos
+        << wxT("<center><h3>")
+        << PreforkProgramName
+        << wxT("</h3></center>")
+        << wxT("<center>");
+}
+
+void AboutDialog::GeneratePreforkTeamMembersInfo(wxTextOutputStream &tos) {
     tos
         << wxT("<p><b>")
         /* i18n-hint: The program's name substitutes for %s */
@@ -1000,6 +933,15 @@ void AboutDialog::GeneratePreforkWebsiteInfo(wxTextOutputStream& tos) {
 #endif
 }
 
+void AboutDialog::GeneratePreforkTrademarkDisclaimer(wxTextOutputStream& tos) {
+
+    tos
+        /* i18n-hint The registered trademark symbol (r) is substituted at %s*/
+        << XO("The Audacity%s trademark is used within this software for descriptive and informational purposes only.").Format("<sup>&reg;</sup>")
+        << wxT("\n")
+        << XO("Tenacity is not produced or endorsed by MuseCY SM Ltd. or Dominic M Mazzoni.");
+}
+
 void AboutDialog::AddCredit(const wxString& name, const Role role) {
     AddCredit(name, {}, role);
 }
@@ -1008,6 +950,7 @@ void AboutDialog::AddCredit(const wxString& name, TranslatableString format, con
     auto str = format.empty()
         ? Verbatim(name)
         : TranslatableString{format}.Format(name);
+
     creditItems.emplace_back(std::move(str), role);
 }
 

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -46,12 +46,13 @@ class AUDACITY_DLL_API AboutDialog final : public wxDialogWrapper{
     enum Role
     {
         roleTenacityTeamMember,
+        roleThanks,
+        roleLibrary,
         rolePreforkTeamMember,
         rolePreforkEmeritusTeam,
         rolePreforkDeceased,
         rolePreforkContributor,
         rolePreforkGraphics,
-        roleLibrary,
         rolePreforkThanks
     };
 
@@ -63,6 +64,7 @@ class AUDACITY_DLL_API AboutDialog final : public wxDialogWrapper{
     static wxImage GenerateTenacityLogoRescaledImage(const float fScale);
     void GenerateTenacityPageDescription(wxTextOutputStream & tos);
     void GenerateTenacityTeamMembersInfo(wxTextOutputStream & tos);
+    void GenerateSpecialThanksInfo(wxTextOutputStream & tos);
     void GenerateTenacityLibsInfo(wxTextOutputStream & tos);
 
     void GeneratePreforkTeamMembersInfo(wxTextOutputStream & tos);

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -32,6 +32,10 @@ class AUDACITY_DLL_API AboutDialog final : public wxDialogWrapper{
 
     public:
 
+    static constexpr int ABOUT_DIALOG_WIDTH = 506;
+    static constexpr int ABOUT_DIALOG_HEIGHT = 359;
+    static const inline wxSize ABOUT_DIALOG_DEFAULT_SIZE = wxSize(ABOUT_DIALOG_WIDTH, ABOUT_DIALOG_HEIGHT);
+
     AboutDialog() : AboutDialog(nullptr){};
     AboutDialog(wxWindow * parent);
     virtual ~AboutDialog();
@@ -46,7 +50,7 @@ class AUDACITY_DLL_API AboutDialog final : public wxDialogWrapper{
     enum Role
     {
         roleTenacityTeamMember,
-        roleThanks,
+        roleTenacityThanks,
         roleLibrary,
         rolePreforkTeamMember,
         rolePreforkEmeritusTeam,
@@ -64,9 +68,10 @@ class AUDACITY_DLL_API AboutDialog final : public wxDialogWrapper{
     static wxImage GenerateTenacityLogoRescaledImage(const float fScale);
     void GenerateTenacityPageDescription(wxTextOutputStream & tos);
     void GenerateTenacityTeamMembersInfo(wxTextOutputStream & tos);
-    void GenerateSpecialThanksInfo(wxTextOutputStream & tos);
+    void GenerateTenacitySpecialThanksInfo(wxTextOutputStream & tos);
     void GenerateTenacityLibsInfo(wxTextOutputStream & tos);
 
+    void GeneratePreforkSubheader(wxTextOutputStream & tos);
     void GeneratePreforkTeamMembersInfo(wxTextOutputStream & tos);
     void GeneratePreforkEmeritusInfo(wxTextOutputStream & tos);
     void GeneratePreforkContributorInfo(wxTextOutputStream & tos);
@@ -74,16 +79,15 @@ class AUDACITY_DLL_API AboutDialog final : public wxDialogWrapper{
     void GeneratePreforkTranslatorsInfo(wxTextOutputStream & tos);
     void GeneratePreforkSpecialThanksInfo(wxTextOutputStream & tos);
     void GeneratePreforkWebsiteInfo(wxTextOutputStream & tos);
+    void GeneratePreforkTrademarkDisclaimer(wxTextOutputStream & tos);
 
     void PopulateCreditsList();
     void AddCredit(const wxString & name, Role role);
     void AddCredit(const wxString & name, TranslatableString format, Role role);
     wxString GetCreditsByRole(Role role);
 
-    static void AddBuildInfoRow(wxTextOutputStream * str, const wxChar * libname,
-                                const TranslatableString & libdesc, const TranslatableString & status);
-    static void AddBuildInfoRow(wxTextOutputStream * str,
-                                const TranslatableString & description, const wxChar * spec);
+    static void AddBuildInfoRow(wxTextOutputStream * str, const wxChar * libname, const TranslatableString & libdesc, const TranslatableString & status);
+    static void AddBuildInfoRow(wxTextOutputStream * str, const TranslatableString & description, const wxChar * spec);
 };
 
 #endif

--- a/src/BuildInfo.h
+++ b/src/BuildInfo.h
@@ -1,0 +1,125 @@
+/**********************************************************************
+
+  Tenacity
+
+  BuildInfo.h
+
+**********************************************************************/
+
+#ifndef BUILD_INFO_H
+#define BUILD_INFO_H
+
+#include <wx/string.h>
+
+// RevisionIdent contains the REV_TIME and REV_LONG defines from git commit information
+#include "RevisionIdent.h"
+
+
+//This needs to be outside the #ifdef or it won't end up in the POT file consistently
+
+
+
+
+// This define replaces the original that modified the macro in wxwidgets
+#define CUSTOM_wxMAKE_VERSION_DOT_STRING_T(x, y, z) wxSTRINGIZE_T(x) wxT(".") wxSTRINGIZE_T(y) wxT(".") wxSTRINGIZE_T(z) wxT("(Tenacity)")
+
+class BuildInfo {
+    
+public:
+      const enum class CompilerType { MSVC, MinGW, GCC, Clang, Unknown };
+
+      static constexpr auto CurrentBuildCompiler =
+        #if defined(_MSC_FULL_VER)
+              CompilerType::MSVC;
+        #elif defined(__GNUC_PATCHLEVEL__) && defined(__MINGW32__)
+              CompilerType::MinGW;
+        #elif defined(__GNUC_PATCHLEVEL__)
+              CompilerType::GCC;
+        #elif defined(__clang_version__)
+              CompilerType::Clang;
+        #else
+              CompilerType::Unknown;
+        #endif
+
+        static const inline wxString getCompilerVersionString(){
+
+          switch (BuildInfo::CurrentBuildCompiler) {
+
+          case BuildInfo::CompilerType::MSVC:
+            return wxString::Format(wxT("MSVC %02d.%02d.%05d.%02d"), _MSC_VER / 100, _MSC_VER % 100, _MSC_FULL_VER % 100000, _MSC_BUILD);
+
+          case BuildInfo::CompilerType::MinGW:
+            return wxString::Format(wxT("MinGW "), CUSTOM_wxMAKE_VERSION_DOT_STRING_T( __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__));
+
+          case BuildInfo::CompilerType::GCC:
+            return wxString::Format(wxT("GCC "), CUSTOM_wxMAKE_VERSION_DOT_STRING_T( __GNUC__, __GNUC_MINOR__, __GNUC_PATCHLEVEL__));
+
+          case BuildInfo::CompilerType::Clang:
+            return wxString::Format( wxT("clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
+
+          case BuildInfo::CompilerType::Unknown:
+          default:
+            return wxT("Unknown!!!");
+          }
+        };
+
+        static const inline wxString getRevisionIdentifier(){
+        
+            static wxString NoRevisionText = XO("No revision identifier was provided").Translation();
+
+            #ifdef REV_LONG
+                return wxString( "[[https://github.com/tenacityteam/tenacity/commit/" ) + REV_LONG + "|" + wxString( REV_LONG ).Left(6) + "]] of " +  getRevisionDateTime();
+            #else
+                return NoRevisionText;
+            #endif
+        }
+
+        static const inline wxString getRevisionDateTime(){
+
+            
+            //This needs to be outside the #ifdef or it won't end up in the POT file consistently
+            static wxString NoDateTimeText = XO("Unknown date and time").Translation();
+
+            #ifdef REV_TIME
+                return wxString(REV_TIME);
+            #else
+                return NoDateTimeText;
+            #endif
+        }
+
+        static constexpr inline bool is64bits(){
+            return (sizeof(void*) == 8);
+        }
+
+        static constexpr inline bool isCMakeBuild(){
+           #ifdef CMAKE
+                return true;
+           #else
+                return false;
+           #endif
+        }
+
+        static const wxString getBuildType() {
+
+            wxStringOutputStream o;
+            wxTextOutputStream buildTypeString(o);
+
+            if(BuildInfo::isCMakeBuild()){
+                buildTypeString << Verbatim("CMake ");
+            }
+
+            if constexpr (_DEBUG){
+                buildTypeString << XO("Debug build (debug level %d)").Format(wxDEBUG_LEVEL).Translation();
+            }else{
+                buildTypeString << XO("Release build (debug level %d)").Format(wxDEBUG_LEVEL).Translation();
+            }
+
+            if(BuildInfo::is64bits()) {
+                buildTypeString << XO(", 64 bits").Translation();
+            }
+
+
+            return o.GetString();
+        }
+};
+#endif

--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackShifter.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackShifter.cpp
@@ -3,6 +3,7 @@
  @brief headerless file injects method definitions for time shifting of NoteTrack
  */
 
+#ifdef USE_MIDI
 #include "../../../ui/TimeShiftHandle.h"
 #include "../../../../NoteTrack.h"
 #include "../../../../ViewInfo.h"
@@ -60,3 +61,4 @@ template<> template<> auto MakeNoteTrackShifter::Implementation() -> Function {
    };
 }
 static MakeNoteTrackShifter registerMakeNoteTrackShifter;
+#endif


### PR DESCRIPTION
This PR adds a new header called `BuildInfo.h` to cleanly separate the `AboutDialog` related code from the only marginally related issue of build information. It will make maintenance easier, since code which has proper separation of concerns is far easier to read and/or write addendums to. This also fixes a few formatting issues and translation issues present in `AboutDialog.cpp`

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>