### PR TITLE
🎉 Generate manpage with scdoc

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -122,6 +122,13 @@ jobs:
         restore-keys: |
           host-${{ matrix.config.name }}-
 
+      # Install scdoc with conan TODO: Move conan pkg to own repo
+    - name: "[Linux] Install scdoc"
+      if: runner.os == 'Linux'
+      run: |
+        conan remote add rigs-of-rods-deps https://conan.cloudsmith.io/rigs-of-rods/deps/
+        conan install scdoc/1.11.1@anotherfoxguy/stable -g=virtualenv --build=missing
+
     - name: Configure
       env:
         # Apple code signing

--- a/help/CMakeLists.txt
+++ b/help/CMakeLists.txt
@@ -1,3 +1,4 @@
+include( CMakeDependentOption )
 
 set( TARGET manual )
 set( TARGET_ROOT ${topdir}/manual )
@@ -52,9 +53,25 @@ if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin" )
    if( NOT WIN32)
       install( DIRECTORY "${dst}" OPTIONAL
                DESTINATION "${_DATADIR}/tenacity/help" )
-      install( FILES "${_SRCDIR}/tenacity.1"
-               DESTINATION "${_MANDIR}/man1" )
+      
       install( FILES "${_SRCDIR}/tenacity.appdata.xml"
                DESTINATION "${_DATADIR}/metainfo" )
    endif()
+endif()
+
+# Test if scdoc is installed
+find_program(SCDOC_CMD scdoc)
+
+cmake_dependent_option(BUILD_MANPAGE "Build manpage" ON "NOT SCDOC_CMD STREQUAL SCDOC_CMD-NOTFOUND" OFF)
+
+if( BUILD_MANPAGE )
+   add_custom_command( COMMENT "Generating manpage"
+      COMMAND ${SCDOC_CMD} < "${_SRCDIR}/tenacity.1.scd" > "${CMAKE_BINARY_DIR}/help/tenacity.1" 
+      DEPENDS "${_SRCDIR}/tenacity.1.scd"
+      OUTPUT "${CMAKE_BINARY_DIR}/help/tenacity.1" )
+
+   add_custom_target( gen_manpage ALL DEPENDS "${CMAKE_BINARY_DIR}/help/tenacity.1")
+
+   install( FILES "${CMAKE_BINARY_DIR}/help/tenacity.1"
+            DESTINATION "${_MANDIR}/man1" )
 endif()

--- a/scripts/ci/configure.sh
+++ b/scripts/ci/configure.sh
@@ -2,6 +2,11 @@
 
 ((${BASH_VERSION%%.*} >= 4)) || { echo >&2 "$0: Error: Please upgrade Bash."; exit 1; }
 
+if [ -f "activate.sh" ]; then
+    echo "Setting up conan venv"
+    source activate.sh
+fi
+
 set -euxo pipefail
 
 conan --version # check it works


### PR DESCRIPTION
CMake will now generate the manpage if scdoc is installed

Closes #358
Fixes #367


<details>
<summary>Contributor stuff</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

</details>