### PR TITLE
[CI] Install conan using pkg manager instead of pip

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -71,6 +71,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
 
+    - name: Add conan to path
+      if: runner.os == 'Windows'
+      run: echo "C:\Program Files\Conan\conan\" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      shell: pwsh
+
     - name: Dependencies
       run: |
         exec bash "scripts/ci/dependencies.sh"
@@ -97,10 +102,6 @@ jobs:
     - name: "[Windows] Remove MinGW link"
       if: runner.os == 'Windows'
       run: rm "C:/Program Files/Git/usr/bin/link.EXE"
-
-    - name: "[Windows] Install sccache"
-      if: runner.os == 'Windows'
-      run: choco install sccache
 
     - name: "Set up compiler cache"
       uses: actions/cache@v2

--- a/scripts/ci/dependencies.sh
+++ b/scripts/ci/dependencies.sh
@@ -6,11 +6,19 @@ set -euxo pipefail
 
 if [[ "${OSTYPE}" == msys* ]]; then # Windows
 
-    # Python packages
-    pip_packages=(
-        conan
-    )
-    pip3 install "${pip_packages[@]}"
+    if which choco; then
+
+        # Chocolatey packages
+        choco_packages=(
+            sccache 
+            conan
+        )
+
+        choco install "${choco_packages[@]}" -y
+    else
+        echo >&2 "$0: Error: You don't have a recognized package manager installed."
+        exit 1
+    fi
 
 elif [[ "${OSTYPE}" == darwin* ]]; then # macOS
 
@@ -41,24 +49,17 @@ else # Linux & others
             libasound2-dev
             libgtk2.0-dev
             gettext
-            python3-pip
             ccache
         )
         sudo apt-get update -y
         sudo apt-get install -y --no-install-recommends "${apt_packages[@]}"
+        
+        # Download Conan from github
+        wget "https://github.com/conan-io/conan/releases/latest/download/conan-ubuntu-64.deb" -nv -O /tmp/conan.deb
+        sudo dpkg -i /tmp/conan.deb
     else
         echo >&2 "$0: Error: You don't have a recognized package manager installed."
         exit 1
     fi
-
-    # Python packages
-    pip_packages=(
-        conan
-    )
-
-    which cmake || pip_packages+=( cmake ) # get latest CMake when inside Docker image
-
-    pip3 install wheel setuptools # need these first to install other packages (e.g. conan)
-    pip3 install "${pip_packages[@]}"
 
 fi


### PR DESCRIPTION
This should install Conan a little faster than pip

<details>
<summary>Contributor stuff</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

</details>