### PR TITLE
Fix bug in `cmake_build.yml`

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -126,7 +126,7 @@ jobs:
     - name: "[Linux] Install scdoc"
       if: runner.os == 'Linux'
       run: |
-        conan remote add rigs-of-rods-deps https://conan.cloudsmith.io/rigs-of-rods/deps/
+        conan remote add -f rigs-of-rods-deps https://conan.cloudsmith.io/rigs-of-rods/deps/
         conan install scdoc/1.11.1@anotherfoxguy/stable -g=virtualenv --build=missing
 
     - name: Configure


### PR DESCRIPTION
`conan remote add` throws an error by default if the remote already exists. The recent PR https://github.com/tenacityteam/tenacity/pull/368 would work initially, but repeated runs of the Linux CI builds will continue to fail until conan is instructed to forcibly add the remote even if it already exists. 

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>



<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>