### PR TITLE
Change configuration and data directories

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -187,7 +187,11 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
 #endif
 
     // Location of settings
-    AddBuildInfoRow(&informationStr, XO("Settings folder:"), FileNames::DataDir());
+    AddBuildInfoRow(&informationStr, XO("Config folder:"), \
+        FileNames::ConfigDir());
+    // Location of data
+    AddBuildInfoRow(&informationStr, XO("Data folder:"), \
+        FileNames::DataDir());
 
     informationStr
         << wxT("<h3>")

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -681,7 +681,7 @@ IMPLEMENT_WX_THEME_SUPPORT
 int main(int argc, char* argv[]) {
     wxDISABLE_DEBUG_SUPPORT();
 
-    // Bug #1986 workaround - This doesn't actually reduce the number of 
+    // Bug #1986 workaround - This doesn't actually reduce the number of
     // messages, it simply hides them in Release builds. We'll probably
     // never be able to get rid of the messages entirely, but we should
     // look into what's causing them, so allow them to show in Debug
@@ -1048,6 +1048,9 @@ bool AudacityApp::OnInit() {
     // AddHandler takes ownership
     wxFileSystem::AddHandler(safenew wxZipFSHandler);
 
+    // encouraged by wxwidgets
+    wxStandardPaths::Get().SetFileLayout(wxStandardPaths::FileLayout::FileLayout_XDG);
+
     //
     // Paths: set search path and temp dir path
     //
@@ -1197,7 +1200,7 @@ bool AudacityApp::OnInit() {
 
     // Initialize preferences and language
     {
-        wxFileName configFileName(FileNames::DataDir(), wxT("tenacity.cfg"));
+        wxFileName configFileName(FileNames::ConfigDir(), wxT("tenacity.cfg"));
         auto appName = wxTheApp->GetAppName();
         InitPreferences(AudacityFileConfig::Create(
             appName, wxEmptyString,
@@ -1309,7 +1312,7 @@ bool AudacityApp::InitPart2() {
 
     AudacityProject* project;
     {
-        // Bug 718: Position splash screen on same screen 
+        // Bug 718: Position splash screen on same screen
         // as where Audacity project will appear.
         wxRect wndRect;
         bool bMaximized = false;
@@ -1326,11 +1329,11 @@ bool AudacityApp::InitPart2() {
             wxDefaultSize,
             wxSTAY_ON_TOP);
 
-        // Unfortunately with the Windows 10 Creators update, the splash screen 
+        // Unfortunately with the Windows 10 Creators update, the splash screen
         // now appears before setting its position.
-        // On a dual monitor screen it will appear on one screen and then 
+        // On a dual monitor screen it will appear on one screen and then
         // possibly jump to the second.
-        // We could fix this by writing our own splash screen and using Hide() 
+        // We could fix this by writing our own splash screen and using Hide()
         // until the splash scren was correctly positioned, then Show()
 
         // Possibly move it on to the second screen...

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -47,6 +47,11 @@ used throughout Audacity into this one place.
 #include <windows.h>
 #endif
 
+#if defined(__WXGTK__)
+static wxString gOldUnixDataDir;
+#endif
+
+static wxString gConfigDir;
 static wxString gDataDir;
 
 const FileNames::FileType
@@ -176,7 +181,7 @@ bool FileNames::HardLinkFile( const FilePath& file1, const FilePath& file2 )
 #ifdef __WXMSW__
 
    // Fix forced ASCII conversions and wrong argument order - MJB - 29/01/2019
-   //return ::CreateHardLinkA( file1.c_str(), file2.c_str(), NULL );  
+   //return ::CreateHardLinkA( file1.c_str(), file2.c_str(), NULL );
    return ( 0 != ::CreateHardLink( file2, file1, NULL ) );
 
 #else
@@ -226,8 +231,49 @@ wxString FileNames::LowerCaseAppNameInPath( const wxString & dirIn){
    return dir;
 }
 
+FilePath FileNames::ConfigDir()
+{
+#if defined(__WXGTK__)
+   if (gOldUnixDataDir.empty())
+      gOldUnixDataDir = wxFileName::GetHomeDir() + wxT("/.audacity-data");
+#endif
+
+   if (gConfigDir.empty())
+   {
+      wxFileName exePath(PlatformCompatibility::GetExecutablePath());
+#if defined(__WXMAC__)
+      // Path ends for example in "Audacity.app/Contents/MacOSX"
+      // just remove the MacOSX part.
+      exePath.RemoveLastDir();
+#endif
+      wxFileName portablePrefsPath(exePath.GetPath(), wxT("Portable Settings"));
+      if (::wxDirExists(portablePrefsPath.GetFullPath()))
+      {
+         // Use "Portable Settings" folder
+         gConfigDir = portablePrefsPath.GetFullPath();
+#if defined(__WXGTK__)
+      } else if (::wxDirExists(gOldUnixDataDir))
+      {
+         // Use old user data dir folder
+         gConfigDir = gOldUnixDataDir;
+#endif
+      } else {
+         // Use OS-provided user data dir folder
+         wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("/audacity"));
+         gConfigDir = FileNames::MkDir(configDir);
+      }
+   }
+
+   return gConfigDir;
+}
+
+
 FilePath FileNames::DataDir()
 {
+#if defined(__WXGTK__)
+    if (gOldUnixDataDir.empty())
+        gOldUnixDataDir = wxFileName::GetHomeDir() + wxT("/.audacity-data");
+#endif
    // LLL:  Wouldn't you know that as of WX 2.6.2, there is a conflict
    //       between wxStandardPaths and wxConfig under Linux.  The latter
    //       creates a normal file as "$HOME/.audacity", while the former
@@ -251,12 +297,25 @@ FilePath FileNames::DataDir()
       {
          // Use "Portable Settings" folder
          gDataDir = portablePrefsPath.GetFullPath();
+#if defined(__WXGTK__)
+      } else if (::wxDirExists(gOldUnixDataDir))
+      {
+         // Use old user data dir folder
+         gDataDir = gOldUnixDataDir;
+      } else
+      {
+         wxString dataDir;
+         // see if XDG_DATA_HOME is defined. if it is, use its value. if it isn't, use the default
+         // XDG-specified value
+         if ( !wxGetEnv(wxS("XDG_DATA_HOME"), &dataDir) || dataDir.empty() )
+            dataDir = wxFileName::GetHomeDir() + wxT("/.local/share");
+
+         dataDir = dataDir + wxT("/audacity");
+#else
       } else
       {
          // Use OS-provided user data dir folder
          wxString dataDir( LowerCaseAppNameInPath( wxStandardPaths::Get().GetUserDataDir() ));
-#if defined( __WXGTK__ )
-         dataDir = dataDir + wxT("-data");
 #endif
          gDataDir = FileNames::MkDir(dataDir);
       }
@@ -317,12 +376,12 @@ FilePath FileNames::PlugInDir()
 
 FilePath FileNames::PluginRegistry()
 {
-   return wxFileName( DataDir(), wxT("pluginregistry.cfg") ).GetFullPath();
+   return wxFileName( ConfigDir(), wxT("pluginregistry.cfg") ).GetFullPath();
 }
 
 FilePath FileNames::PluginSettings()
 {
-   return wxFileName( DataDir(), wxT("pluginsettings.cfg") ).GetFullPath();
+   return wxFileName( ConfigDir(), wxT("pluginsettings.cfg") ).GetFullPath();
 }
 
 FilePath FileNames::BaseDir()
@@ -472,7 +531,7 @@ wxFileNameWrapper FileNames::DefaultToDocumentsFolder(const wxString &preference
 
    // MJB: Bug 1899 & Bug 2007.  Only create directory if the result is the default path
    bool bIsDefaultPath = result == defaultPath;
-   if( !bIsDefaultPath ) 
+   if( !bIsDefaultPath )
    {
       // IF the prefs directory doesn't exist - (Deleted by our user perhaps?)
       //    or exists as a file

--- a/src/FileNames.cpp
+++ b/src/FileNames.cpp
@@ -47,10 +47,6 @@ used throughout Audacity into this one place.
 #include <windows.h>
 #endif
 
-#if defined(__WXGTK__)
-static wxString gOldUnixDataDir;
-#endif
-
 static wxString gConfigDir;
 static wxString gDataDir;
 
@@ -233,16 +229,11 @@ wxString FileNames::LowerCaseAppNameInPath( const wxString & dirIn){
 
 FilePath FileNames::ConfigDir()
 {
-#if defined(__WXGTK__)
-   if (gOldUnixDataDir.empty())
-      gOldUnixDataDir = wxFileName::GetHomeDir() + wxT("/.audacity-data");
-#endif
-
    if (gConfigDir.empty())
    {
       wxFileName exePath(PlatformCompatibility::GetExecutablePath());
 #if defined(__WXMAC__)
-      // Path ends for example in "Audacity.app/Contents/MacOSX"
+      // Path ends for example in "Tenacity.app/Contents/MacOSX"
       // just remove the MacOSX part.
       exePath.RemoveLastDir();
 #endif
@@ -251,15 +242,13 @@ FilePath FileNames::ConfigDir()
       {
          // Use "Portable Settings" folder
          gConfigDir = portablePrefsPath.GetFullPath();
-#if defined(__WXGTK__)
-      } else if (::wxDirExists(gOldUnixDataDir))
-      {
-         // Use old user data dir folder
-         gConfigDir = gOldUnixDataDir;
-#endif
       } else {
          // Use OS-provided user data dir folder
-         wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("/audacity"));
+#if defined(__WSMSW__)
+         wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("\\Tenacity"));
+#else
+         wxString configDir(wxStandardPaths::Get().GetUserConfigDir() + wxT("/tenacity"));
+#endif
          gConfigDir = FileNames::MkDir(configDir);
       }
    }
@@ -270,10 +259,6 @@ FilePath FileNames::ConfigDir()
 
 FilePath FileNames::DataDir()
 {
-#if defined(__WXGTK__)
-    if (gOldUnixDataDir.empty())
-        gOldUnixDataDir = wxFileName::GetHomeDir() + wxT("/.audacity-data");
-#endif
    // LLL:  Wouldn't you know that as of WX 2.6.2, there is a conflict
    //       between wxStandardPaths and wxConfig under Linux.  The latter
    //       creates a normal file as "$HOME/.audacity", while the former
@@ -298,10 +283,6 @@ FilePath FileNames::DataDir()
          // Use "Portable Settings" folder
          gDataDir = portablePrefsPath.GetFullPath();
 #if defined(__WXGTK__)
-      } else if (::wxDirExists(gOldUnixDataDir))
-      {
-         // Use old user data dir folder
-         gDataDir = gOldUnixDataDir;
       } else
       {
          wxString dataDir;
@@ -310,7 +291,7 @@ FilePath FileNames::DataDir()
          if ( !wxGetEnv(wxS("XDG_DATA_HOME"), &dataDir) || dataDir.empty() )
             dataDir = wxFileName::GetHomeDir() + wxT("/.local/share");
 
-         dataDir = dataDir + wxT("/audacity");
+         dataDir = dataDir + wxT("/tenacity");
 #else
       } else
       {
@@ -341,7 +322,7 @@ FilePath FileNames::HtmlHelpDir()
    //for mac this puts us within the .app: Tenacity.app/Contents/SharedSupport/
    return wxFileName( exePath.GetPath()+wxT("/help/manual"), wxEmptyString ).GetFullPath();
 #else
-   //linux goes into /*prefix*/share/audacity/
+   //linux goes into /*prefix*/share/tenacity/
    //windows (probably) goes into the dir containing the .exe
    wxString dataDir = FileNames::LowerCaseAppNameInPath( wxStandardPaths::Get().GetDataDir());
    return wxFileName( dataDir+wxT("/help/manual"), wxEmptyString ).GetFullPath();
@@ -401,7 +382,7 @@ FilePath FileNames::BaseDir()
    // the "Debug" directory in debug builds.
    baseDir = PlatformCompatibility::GetExecutablePath();
 #else
-   // Linux goes into /*prefix*/share/audacity/
+   // Linux goes into /*prefix*/share/tenacity/
    baseDir = FileNames::LowerCaseAppNameInPath(wxStandardPaths::Get().GetPluginsDir());
 #endif
 

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -75,7 +75,7 @@ namespace FileNames
       , DynamicLibraries // depends on the operating system
       , TextFiles // *.txt
       , XMLFiles; // *.xml, *.XML
-   
+
    using FileTypes = std::vector< FileType >;
 
    // Convert fileTypes into a single string as expected by wxWidgets file
@@ -112,10 +112,15 @@ namespace FileNames
       FilePaths &otherNames, wxFileName &newName);
 
    AUDACITY_DLL_API wxString LowerCaseAppNameInPath( const wxString & dirIn);
+   /** \brief Audacity user config directory
+    *
+    * Where audacity keeps its settigns squirreled away, by default ~/.config/audacity/
+    * on Unix, Application Data/Audacity on Windows */
+   FilePath ConfigDir();
    /** \brief Audacity user data directory
     *
     * Where audacity keeps its settings and other user data squirreled away,
-    * by default ~/.audacity-data/ on Unix, Application Data/Audacity on
+    * by default ~/.local/share/audacity/ on Unix, Application Data/Audacity on
     * windows system */
    AUDACITY_DLL_API FilePath DataDir();
    AUDACITY_DLL_API FilePath ResourcesDir();

--- a/src/FileNames.h
+++ b/src/FileNames.h
@@ -112,15 +112,15 @@ namespace FileNames
       FilePaths &otherNames, wxFileName &newName);
 
    AUDACITY_DLL_API wxString LowerCaseAppNameInPath( const wxString & dirIn);
-   /** \brief Audacity user config directory
+   /** \brief Tenacity user config directory
     *
-    * Where audacity keeps its settigns squirreled away, by default ~/.config/audacity/
-    * on Unix, Application Data/Audacity on Windows */
+    * Where Tenacity keeps its settigns squirreled away, by default ~/.config/tenacity/
+    * on Unix, Application Data/Tenacity on Windows */
    FilePath ConfigDir();
-   /** \brief Audacity user data directory
+   /** \brief Tenacity user data directory
     *
-    * Where audacity keeps its settings and other user data squirreled away,
-    * by default ~/.local/share/audacity/ on Unix, Application Data/Audacity on
+    * Where Tenacity keeps its settings and other user data squirreled away,
+    * by default ~/.local/share/tenacity/ on Unix, Application Data/Tenacity on
     * windows system */
    AUDACITY_DLL_API FilePath DataDir();
    AUDACITY_DLL_API FilePath ResourcesDir();


### PR DESCRIPTION
Signed-off-by: Campbell Jones <git@serebit.com>
Signed-off-by: Sol Fisher Romanoff <sol@solfisher.com>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #231

Port of audacity/audacity#831 by @serebit -- Change the Unix default config directory to `~/.config/audacity`.

Additional things which need to be done:

- [x] Deprecate `.audacity-data` entirely: excusable on Audacity for backwards compatibility, but this is a new program.
- [x] Change the directory names to have Tenacity rather than Audacity.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>