### PR TITLE
Snap items to selection/edit cursor

### DIFF
--- a/src/Snap.cpp
+++ b/src/Snap.cpp
@@ -77,6 +77,9 @@ void SnapManager::Reinit()
    int snapTo = settings.GetSnapTo();
    double rate = settings.GetRate();
    auto format = settings.GetSelectionFormat();
+   auto &viewInfo = ViewInfo::Get( *mProject );
+   const double t0 = viewInfo.selectedRegion.t0();
+   const double t1 = viewInfo.selectedRegion.t1();
 
    // No need to reinit if these are still the same
    if (snapTo == mSnapTo && rate == mRate && format == mFormat)
@@ -104,6 +107,10 @@ void SnapManager::Reinit()
 
    // Add a SnapPoint at t=0
    mSnapPoints.push_back(SnapPoint{});
+
+   // Add SnapPoints for selection start and end
+   mSnapPoints.push_back(SnapPoint{ t0 });
+   if (t0 != t1) mSnapPoints.push_back(SnapPoint{ t1 });
 
    // Adjust and filter the candidate points
    for (const auto &candidate : mCandidates)


### PR DESCRIPTION
Makes item snap to selection start and end points.
Also makes items snap to edit cursor since it follows the selection start point.

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/386 

Adds t0 & t1 to the list of snapping points.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>