### PR TITLE
Draw v-ruler border in height with affordances

### DIFF
--- a/src/TrackPanel.cpp
+++ b/src/TrackPanel.cpp
@@ -1291,6 +1291,13 @@ public:
          context.dc.DrawRectangle(rect);
          wxRect bevel(rect.x, rect.y, rect.width - 1, rect.height - 1);
          AColor::BevelTrackInfo(context.dc, true, bevel, false);
+         // Stroke the left border
+        context.dc.SetPen(*wxBLACK_PEN);
+        {
+           const auto left = rect.GetLeft();
+           AColor::Line( context.dc, left - 1, rect.GetTop(),
+               left - 1, rect.GetBottom() );
+        }
       }
    }
 


### PR DESCRIPTION
The affordances made parts of the 1px black border between v-ruler and track controls not draw properly. This resulted in graphical glitches where the border should be while resizing window or track height.

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/328


<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>