### PR TITLE
Make CodeQL analysis use GCC 11

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,7 +60,13 @@ jobs:
             language: 'cpp'  # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
        
     steps:
-  
+    # Setup 64-bit GCC 11
+    - name: Set up GCC
+      uses: egor-tensin/setup-gcc@v1
+      with:
+        platform: x64
+        version: 11
+
     - name: Checkout repository
       uses: actions/checkout@v2
     - name: Dependencies
@@ -91,8 +97,6 @@ jobs:
         APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
         APPLE_NOTARIZATION_USER_NAME: ${{ secrets.APPLE_NOTARIZATION_USER_NAME }}
         APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
-        CC: ${{ matrix.config.cc }}
-        CXX: ${{ matrix.config.cxx }}
       run: |
         exec bash "scripts/ci/configure.sh"
     # Initializes the CodeQL tools for scanning.
@@ -107,9 +111,6 @@ jobs:
     - name: Build
       run: |
         exec bash "scripts/ci/build.sh"
-    - name: Install
-      run: |
-        exec bash "scripts/ci/install.sh"
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
 


### PR DESCRIPTION
Use an action to automatically install GCC 11 on the CodeQL CI env.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>