### PR TITLE
Fix for unsafe `ctime` usage (CWE-676)

### DIFF
--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -26,6 +26,10 @@ but it will probably work fine if you use it on a high level.
 #include <stdio.h>
 #include <string.h>
 #include <wx/crt.h>
+#include <time.h>
+#include <chrono>
+#define __STDC_FORMAT_MACROS 1
+#include <inttypes.h>
 
 ///write to a profile at the end of the test.
 Profiler::~Profiler()
@@ -33,12 +37,12 @@ Profiler::~Profiler()
    if(mTasks.size())
    {
       //print everything out.  append to a log.
-      FILE* log = fopen("AudacityProfilerLog.txt", "a");
-      time_t now;
+      FILE* log = fopen("TenacityProfilerLog.txt", "a");
+      const auto now = std::chrono::system_clock::now();
+      const std::uint64_t timestamp_ms = now.time_since_epoch() / std::chrono::milliseconds(1);
 
-      time(&now);
-      wxFprintf(log,"Audacity Profiler Run, Ended at ");
-      wxFprintf(log,"%s",ctime(&now));
+      wxFprintf(log,"Tenacity Profiler Run, Ended at ");
+      wxFprintf(log,"%" PRIu64,timestamp_ms);
       wxFprintf(log,"****************************************\n");
       //print out the tasks
       for(int i=0;i<(int)mTasks.size();i++)

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -28,7 +28,6 @@ but it will probably work fine if you use it on a high level.
 #define __AUDACITY_PROFILER__
 #include <mutex>
 #include <vector>
-#include <time.h>
 #include "MemoryX.h"
 
 


### PR DESCRIPTION
Replace unneeded and unsafe usage of `ctime` with `chrono` based timing.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>