### PR TITLE
Use git-describe in versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,22 +21,6 @@ endif ()
 # Set this value to 0 for alpha, 1 for beta, 2 for release builds
 set( AUDACITY_BUILD_LEVEL 0 )
 
-# The Audacity version
-# Increment as appropriate after release of a new version, and set back
-# AUDACITY_BUILD_LEVEL to 0
-set( AUDACITY_VERSION 3 )
-set( AUDACITY_RELEASE 0 )
-set( AUDACITY_REVISION 4 )
-set( AUDACITY_MODLEVEL 0 )
-
-if( AUDACITY_BUILD_LEVEL EQUAL 0 )
-   set( AUDACITY_SUFFIX "-alpha" )
-elseif(  AUDACITY_BUILD_LEVEL EQUAL 1 )
-   set( AUDACITY_SUFFIX "-beta" )
-else()
-   set( AUDACITY_SUFFIX "" )
-endif()
-
 # Don't allow in-source builds...no real reason, just
 # keeping those source trees nice and tidy.  :-)
 # (This can be removed if it becomes an issue.)
@@ -232,31 +216,44 @@ elseif( CMAKE_SYSTEM_NAME MATCHES "Darwin" )
 
 endif()
 
-# Try to get the current commit information
-set( GIT_COMMIT_SHORT "unknown" )
-set( GIT_COMMIT_LONG "unknown" )
-set( GIT_COMMIT_TIME "unknown" )
+# Current version and commit info
+set( AUDACITY_VERSION 0 )
+set( AUDACITY_RELEASE 0 )
+set( AUDACITY_REVISION 0 )
+set( GIT_DESCRIBE "unknown" )
 find_package( Git QUIET )
 if( GIT_FOUND )
-   execute_process(
-      COMMAND
-         ${GIT_EXECUTABLE} show -s "--format=%h;%H;%cd" --no-show-signature --no-notes
-      WORKING_DIRECTORY
-         ${topdir}
-      OUTPUT_VARIABLE
-         git_output
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      ERROR_QUIET
-   )
+    execute_process(
+        COMMAND
+            ${GIT_EXECUTABLE} describe --abbrev=7
+        WORKING_DIRECTORY
+            ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE
+            GIT_DESCRIBE
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
 
-   if( git_output )
-      list( GET git_output 0 GIT_COMMIT_SHORT )
-      list( GET git_output 1 GIT_COMMIT_LONG )
-      list( GET git_output 2 GIT_COMMIT_TIME )
-   endif()
+    if( GIT_DESCRIBE )
+        # Copy to new variable for string manipulation
+        set( git_output ${GIT_DESCRIBE} )
+
+        # TODO: Remove this after first Tenacity release
+        string(REPLACE "Audacity-" "" git_output "${git_output}")
+
+        string( REGEX REPLACE "-.*" "" git_output "${git_output}" )
+        string( REPLACE "." ";" git_output "${git_output}" )
+
+        list( GET git_output 0 AUDACITY_VERSION )
+        list( GET git_output 1 AUDACITY_RELEASE )
+        list( GET git_output 2 AUDACITY_REVISION )
+    endif()
 endif()
-message( STATUS "  Current Commit: ${GIT_COMMIT_SHORT}" )
+message( STATUS "  Current Commit: ${GIT_DESCRIBE}" )
 message( STATUS )
+
+# Not sure what this even does
+set( AUDACITY_MODLEVEL 0 )
 
 # Organize subdirectories/targets into folders for the IDEs
 set_property( GLOBAL PROPERTY USE_FOLDERS ON )
@@ -488,10 +485,6 @@ if( CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
 else()
    set( AUDACITY_NAME "tenacity" )
 endif()
-
-# Create short and full version strings
-set( AUDACITY_DIST_VERSION ${AUDACITY_VERSION}.${AUDACITY_RELEASE}.${AUDACITY_REVISION} )
-set( AUDACITY_INFO_VERSION ${AUDACITY_VERSION}.${AUDACITY_RELEASE}.${AUDACITY_REVISION}.${AUDACITY_MODLEVEL} )
 
 # Python is used for the manual and (possibly) message catalogs
 find_package( Python3 )

--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -232,7 +232,7 @@ function( audacity_append_common_compiler_options var use_pch )
          -DAUDACITY_MODLEVEL=${AUDACITY_MODLEVEL}
 
          # Version string for visual display
-         -DAUDACITY_VERSION_STRING=L"${AUDACITY_VERSION}.${AUDACITY_RELEASE}.${AUDACITY_REVISION}${AUDACITY_SUFFIX}"
+         -DAUDACITY_VERSION_STRING=L"${GIT_DESCRIBE}"
 
          # This value is used in the resource compiler for Windows
          -DAUDACITY_FILE_VERSION=L"${AUDACITY_VERSION},${AUDACITY_RELEASE},${AUDACITY_REVISION},${AUDACITY_MODLEVEL}"

--- a/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
+++ b/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
@@ -206,7 +206,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Wrapper</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Audacity version ${AUDACITY_INFO_VERSION}</string>
+	<string>Audacity version ${GIT_DESCRIBE}</string>
 	<key>CFBundleIconFile</key>
 	<string>Audacity.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -214,17 +214,17 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>
-	<string>Version ${AUDACITY_INFO_VERSION}</string>
+	<string>Version ${GIT_DESCRIBE}</string>
 	<key>CFBundleName</key>
 	<string>Audacity</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>${AUDACITY_INFO_VERSION}</string>
+	<string>${GIT_DESCRIBE}</string>
 	<key>CFBundleSignature</key>
 	<string>auDy</string>
 	<key>CFBundleVersion</key>
-	<string>${AUDACITY_INFO_VERSION}</string>
+	<string>${GIT_DESCRIBE}</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.music</string>
 	<key>NSHighResolutionCapable</key>
@@ -232,7 +232,7 @@
    <key>NSRequiresAquaSystemAppearance</key>
    <true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Audacity version ${AUDACITY_INFO_VERSION}</string>
+	<string>Audacity version ${GIT_DESCRIBE}</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Audacity requires access to the microphone only if you intend to record from it.</string>
 	<key>NSPrincipalClass</key>

--- a/cmake-proxies/cmake-modules/Package.cmake
+++ b/cmake-proxies/cmake-modules/Package.cmake
@@ -1,16 +1,8 @@
-set(CPACK_PACKAGE_VERSION_MAJOR "${AUDACITY_VERSION}") # X
-set(CPACK_PACKAGE_VERSION_MINOR "${AUDACITY_RELEASE}") # Y
-set(CPACK_PACKAGE_VERSION_PATCH "${AUDACITY_REVISION}") # Z
 set(CPACK_PACKAGE_VENDOR "Tenacity")
 set(CPACK_PACKAGE_HOMEPAGE_URL "https://tenacityaudio.org")
 
-# X.Y.Z-alpha-20210615
-set(CPACK_PACKAGE_VERSION "${AUDACITY_VERSION}.${AUDACITY_RELEASE}.${AUDACITY_REVISION}${AUDACITY_SUFFIX}")
-
-if(NOT AUDACITY_BUILD_LEVEL EQUAL 2)
-   # X.Y.Z-alpha-20210615+a1b2c3d
-   set(CPACK_PACKAGE_VERSION "${CPACK_PACKAGE_VERSION}+${GIT_COMMIT_SHORT}")
-endif()
+# X.Y.Z-alpha-1337-gdeadbee
+set(CPACK_PACKAGE_VERSION "${GIT_DESCRIBE}")
 
 # Custom variables use CPACK_AUDACITY_ prefix. CPACK_ to expose to CPack,
 # AUDACITY_ to show it is custom and avoid conflicts with other projects.
@@ -24,12 +16,12 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
    set(os "linux")
 endif()
 
-# tenacity-linux-X.Y.Z-alpha-20210615
+# tenacity-linux-X.Y.Z-alpha-1337-gdeadbee
 set(CPACK_PACKAGE_FILE_NAME "tenacity-${os}-${CPACK_PACKAGE_VERSION}")
 set(zsync_name "tenacity-${os}-*") # '*' is wildcard (here it means any version)
 
 if(DEFINED AUDACITY_ARCH_LABEL)
-   # tenacity-linux-X.Y.Z-alpha-20210615-x86_64
+   # tenacity-linux-X.Y.Z-alpha-1337-gdeadbee-x86_64
    set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_FILE_NAME}-${AUDACITY_ARCH_LABEL}")
    set(zsync_name "${zsync_name}-${AUDACITY_ARCH_LABEL}")
    set(CPACK_AUDACITY_ARCH_LABEL "${AUDACITY_ARCH_LABEL}")

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -46,7 +46,7 @@ list( APPEND EXCLUDES
    win
 )
 
-set( TLD "tenacity-minsrc-${AUDACITY_DIST_VERSION}${AUDACITY_SUFFIX}" )
+set( TLD "tenacity-minsrc-${GIT_DESCRIBE}" )
 set( TARBALL "${PROJECT_BINARY_DIR}/${TLD}.tar.xz" )
 
 add_custom_target( ${TARGET}

--- a/scripts/maketarball.sh
+++ b/scripts/maketarball.sh
@@ -269,14 +269,10 @@ eval $(cpp -E <<CPPEOF | sed -e 's/wxT("//g' \
                              -e '/^v_/p' \
                              -e 'd'
 #include "src/Audacity.h"
-v_major=AUDACITY_VERSION
-v_minor=AUDACITY_RELEASE
-v_micro=AUDACITY_REVISION
-v_suffix=AUDACITY_SUFFIX
 CPPEOF
 )
 
-version="${v_major}.${v_minor}.${v_micro}${v_suffix}"
+version="${GIT_DESCRIBE}"
 printf "${version}\n"
 
 # now clean out the directory of all the things we don't need in the


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #291
Closes: #413 

Use `git describe --abbrev=7` in versions.
This also eliminates the need for `${AUDACITY_VERSION}.${AUDACITY_RELEASE}.${AUDACITY_REVISION}`, as git-describe comes with the latest tag already included.

```
# Before
X.Y.Z-alpha-20210615+a1b2c3d

# After
X.Y.Z-alpha-1337-ga1b2c3d
```

I still need to clean up some artifacts of the previous versioning system.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>