### PR TITLE
ControlToolBar: Reorder icons

### DIFF
--- a/src/toolbars/ControlToolBar.cpp
+++ b/src/toolbars/ControlToolBar.cpp
@@ -81,12 +81,12 @@ IMPLEMENT_CLASS(ControlToolBar, ToolBar);
 
 BEGIN_EVENT_TABLE(ControlToolBar, ToolBar)
    EVT_CHAR(ControlToolBar::OnKeyEvent)
-   EVT_BUTTON(ID_PLAY_BUTTON,   ControlToolBar::OnPlay)
-   EVT_BUTTON(ID_STOP_BUTTON,   ControlToolBar::OnStop)
-   EVT_BUTTON(ID_RECORD_BUTTON, ControlToolBar::OnRecord)
    EVT_BUTTON(ID_REW_BUTTON,    ControlToolBar::OnRewind)
    EVT_BUTTON(ID_FF_BUTTON,     ControlToolBar::OnFF)
+   EVT_BUTTON(ID_STOP_BUTTON,   ControlToolBar::OnStop)
+   EVT_BUTTON(ID_PLAY_BUTTON,   ControlToolBar::OnPlay)
    EVT_BUTTON(ID_PAUSE_BUTTON,  ControlToolBar::OnPause)
+   EVT_BUTTON(ID_RECORD_BUTTON, ControlToolBar::OnRecord)
    EVT_IDLE(ControlToolBar::OnIdle)
 END_EVENT_TABLE()
 
@@ -193,9 +193,19 @@ void ControlToolBar::Populate()
    SetBackgroundColour( theTheme.Colour( clrMedium  ) );
    MakeButtonBackgroundsLarge();
 
-   mPause = MakeButton(this, bmpPause, bmpPause, bmpPauseDisabled,
-      ID_PAUSE_BUTTON,  true,  XO("Pause"));
+   // Rewind button
+   mRewind = MakeButton(this, bmpRewind, bmpRewind, bmpRewindDisabled,
+      ID_REW_BUTTON, false, XO("Skip to Start"));
 
+   // Fast-forward button
+   mFF = MakeButton(this, bmpFFwd, bmpFFwd, bmpFFwdDisabled,
+      ID_FF_BUTTON, false, XO("Skip to End"));
+
+   // Stop button
+   mStop = MakeButton(this, bmpStop, bmpStop, bmpStopDisabled ,
+      ID_STOP_BUTTON, false, XO("Stop"));
+
+   // Play button
    mPlay = MakeButton(this, bmpPlay, bmpPlay, bmpPlayDisabled,
       ID_PLAY_BUTTON, true, XO("Play"));
    MakeAlternateImages(*mPlay, 1, bmpLoop, bmpLoop, bmpLoopDisabled);
@@ -207,15 +217,11 @@ void ControlToolBar::Populate()
                        bmpSeek, bmpSeek, bmpSeekDisabled);
    mPlay->FollowModifierKeys();
 
-   mStop = MakeButton(this, bmpStop, bmpStop, bmpStopDisabled ,
-      ID_STOP_BUTTON, false, XO("Stop"));
+   // Pause button
+   mPause = MakeButton(this, bmpPause, bmpPause, bmpPauseDisabled,
+      ID_PAUSE_BUTTON,  true,  XO("Pause"));
 
-   mRewind = MakeButton(this, bmpRewind, bmpRewind, bmpRewindDisabled,
-      ID_REW_BUTTON, false, XO("Skip to Start"));
-
-   mFF = MakeButton(this, bmpFFwd, bmpFFwd, bmpFFwdDisabled,
-      ID_FF_BUTTON, false, XO("Skip to End"));
-
+   // Record button
    mRecord = MakeButton(this, bmpRecord, bmpRecord, bmpRecordDisabled,
       ID_RECORD_BUTTON, false, XO("Record"));
 
@@ -249,26 +255,26 @@ void ControlToolBar::RegenerateTooltips()
       CommandID name;
       switch (iWinID)
       {
+         case ID_REW_BUTTON:
+            name = wxT("CursProjectStart");
+            break;
+         case ID_FF_BUTTON:
+            name = wxT("CursProjectEnd");
+            break;
+         case ID_STOP_BUTTON:
+            name = wxT("Stop");
+            break;
          case ID_PLAY_BUTTON:
             // Without shift
             name = wxT("PlayStop");
+            break;
+         case ID_PAUSE_BUTTON:
+            name = wxT("Pause");
             break;
          case ID_RECORD_BUTTON:
             // Without shift
             //name = wxT("Record");
             name = wxT("Record1stChoice");
-            break;
-         case ID_PAUSE_BUTTON:
-            name = wxT("Pause");
-            break;
-         case ID_STOP_BUTTON:
-            name = wxT("Stop");
-            break;
-         case ID_FF_BUTTON:
-            name = wxT("CursProjectEnd");
-            break;
-         case ID_REW_BUTTON:
-            name = wxT("CursProjectStart");
             break;
       }
       std::vector<ComponentInterfaceSymbol> commands(
@@ -277,9 +283,23 @@ void ControlToolBar::RegenerateTooltips()
       // Some have a second
       switch (iWinID)
       {
+         case ID_REW_BUTTON:
+            // With shift
+            commands.push_back( {
+               wxT("SelStart"), XO("Select to Start") } );
+            break;
+         case ID_FF_BUTTON:
+            // With shift
+            commands.push_back( {
+               wxT("SelEnd"), XO("Select to End") } );
+            break;
+         case ID_STOP_BUTTON:
+            break;
          case ID_PLAY_BUTTON:
             // With shift
             commands.push_back( { wxT("PlayLooped"), XO("Loop Play") } );
+            break;
+         case ID_PAUSE_BUTTON:
             break;
          case ID_RECORD_BUTTON:
             // With shift
@@ -293,20 +313,6 @@ void ControlToolBar::RegenerateTooltips()
                      : XO("Append Record")
                } );
             }
-            break;
-         case ID_PAUSE_BUTTON:
-            break;
-         case ID_STOP_BUTTON:
-            break;
-         case ID_FF_BUTTON:
-            // With shift
-            commands.push_back( {
-               wxT("SelEnd"), XO("Select to End") } );
-            break;
-         case ID_REW_BUTTON:
-            // With shift
-            commands.push_back( {
-               wxT("SelStart"), XO("Select to Start") } );
             break;
       }
       ToolBar::SetButtonToolTip(
@@ -377,11 +383,11 @@ void ControlToolBar::ArrangeButtons()
       mRewind->MoveBeforeInTabOrder( mRecord );
       mFF->MoveBeforeInTabOrder( mRecord );
 
-      mSizer->Add( mPause,  0, flags, 2 );
-      mSizer->Add( mPlay,   0, flags, 2 );
-      mSizer->Add( mStop,   0, flags, 2 );
       mSizer->Add( mRewind, 0, flags, 2 );
       mSizer->Add( mFF,     0, flags, 10 );
+      mSizer->Add( mStop,   0, flags, 2 );
+      mSizer->Add( mPlay,   0, flags, 2 );
+      mSizer->Add( mPause,  0, flags, 2 );
       mSizer->Add( mRecord, 0, flags, 5 );
    }
    else

--- a/src/toolbars/ControlToolBar.h
+++ b/src/toolbars/ControlToolBar.h
@@ -99,23 +99,25 @@ class AUDACITY_DLL_API ControlToolBar final : public ToolBar {
    void ArrangeButtons();
    TranslatableString StateForStatusBar();
 
+   // Sorted in order of appearance, not alphabetically
+
    enum
    {
-      ID_PAUSE_BUTTON = 11000,
-      ID_PLAY_BUTTON,
-      ID_STOP_BUTTON,
-      ID_FF_BUTTON,
       ID_REW_BUTTON,
+      ID_FF_BUTTON,
+      ID_STOP_BUTTON,
+      ID_PLAY_BUTTON,
+      ID_PAUSE_BUTTON = 11000,
       ID_RECORD_BUTTON,
       BUTTON_COUNT,
    };
 
    AButton *mRewind;
-   AButton *mPlay;
-   AButton *mRecord;
-   AButton *mPause;
-   AButton *mStop;
    AButton *mFF;
+   AButton *mStop;
+   AButton *mPlay;
+   AButton *mPause;
+   AButton *mRecord;
 
    // Activate ergonomic order for transport buttons
    bool mErgonomicTransportButtons;


### PR DESCRIPTION
Alright, so, I know that this change is going to be very controversial, so please allow me to explain. This change only affects the "ergonomic mode" and was directly inspired from my troubles while using Audacity.

- I mostly use the Play/Pause buttons. Afterwards, I use "Stop" and the "Rewind"/"Fast-forward" buttons, especially when I'm editing. I grouped those icons together and put the ones that I primarily use when I am editing, and then moved those icons towards the right. It's easier to make a movement headed downwards, rather than a diagonal one.
- I could move the "Record" button as left as possible (I tried it), but it felt very awkward. It's better to have the "Stop" button immediately within your reach after you start recording, instead of the "Play" button.
- You can also easily stop recording in two ways, because the "Stop" button is right there! It may look a bit weird, but it works just fine. I think that is what matters, right?
- I got some very positive initial feedback. A user that has been following development before we named ourselves "Tenacity" said that it reminded him of a tape recorder. That was not the intent, but you can't say that this doesn't make my change look even cooler. :)

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving\* (N/A)
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>