### PR TITLE
Fix for unsafe `alloca` usage (CWE-770)

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -3844,12 +3844,13 @@ bool AudioIoCallback::FillOutputBuffers(
 
    // ------ MEMORY ALLOCATION ----------------------
    // These are small structures.
-   WaveTrack **chans = (WaveTrack **) alloca(numPlaybackChannels * sizeof(WaveTrack *));
-   float **tempBufs = (float **) alloca(numPlaybackChannels * sizeof(float *));
+   auto chans = new WaveTrack * [numPlaybackChannels];
+   auto tempBufs = new float* [numPlaybackChannels];
 
    // And these are larger structures....
-   for (unsigned int c = 0; c < numPlaybackChannels; c++)
-      tempBufs[c] = (float *) alloca(framesPerBuffer * sizeof(float));
+   for (unsigned int c = 0; c < numPlaybackChannels; c++) {
+       tempBufs[c] = new float[framesPerBuffer];
+   }
    // ------ End of MEMORY ALLOCATION ---------------
 
    auto & em = RealtimeEffectManager::Get();
@@ -4001,6 +4002,8 @@ bool AudioIoCallback::FillOutputBuffers(
    if (outputMeterFloats != outputFloats)
       ClampBuffer( outputMeterFloats, framesPerBuffer*numPlaybackChannels );
 
+   delete[] chans;
+   delete[] tempBufs;
    return false;
 }
 

--- a/src/effects/RealtimeEffectManager.cpp
+++ b/src/effects/RealtimeEffectManager.cpp
@@ -323,15 +323,15 @@ size_t RealtimeEffectManager::RealtimeProcess(int group, unsigned chans, float *
    wxMilliClock_t start = wxGetUTCTimeMillis();
 
    // Allocate the in/out buffer arrays
-   float **ibuf = (float **) alloca(chans * sizeof(float *));
-   float **obuf = (float **) alloca(chans * sizeof(float *));
+   auto ibuf = new float* [chans];
+   auto obuf = new float* [chans];
 
    // And populate the input with the buffers we've been given while allocating
    // NEW output buffers
    for (unsigned int i = 0; i < chans; i++)
    {
       ibuf[i] = buffers[i];
-      obuf[i] = (float *) alloca(numSamples * sizeof(float));
+      obuf[i] = new float[numSamples];
    }
 
    // Now call each effect in the chain while swapping buffer pointers to feed the
@@ -365,6 +365,9 @@ size_t RealtimeEffectManager::RealtimeProcess(int group, unsigned chans, float *
          memcpy(buffers[i], ibuf[i], numSamples * sizeof(float));
       }
    }
+
+   delete ibuf;
+   delete[] obuf;
 
    // Remember the latency
    mRealtimeLatency = (int) (wxGetUTCTimeMillis() - start).GetValue();
@@ -516,9 +519,10 @@ size_t RealtimeEffectState::RealtimeProcess(int group,
    const auto numAudioIn = mEffect.GetAudioInCount();
    const auto numAudioOut = mEffect.GetAudioOutCount();
 
-   float **clientIn = (float **) alloca(numAudioIn * sizeof(float *));
-   float **clientOut = (float **) alloca(numAudioOut * sizeof(float *));
-   float *dummybuf = (float *) alloca(numSamples * sizeof(float));
+   auto clientIn = new float* [numAudioIn];
+   auto clientOut = new float* [numAudioOut];
+   auto dummybuf = new float [numSamples];
+
    decltype(numSamples) len = 0;
    auto ichans = chans;
    auto ochans = chans;
@@ -613,6 +617,9 @@ size_t RealtimeEffectState::RealtimeProcess(int group,
       // Bump to next processor
       processor++;
    }
+   delete[] clientIn;
+   delete[] clientOut;
+   delete[] dummybuf;
 
    return len;
 }


### PR DESCRIPTION
Removed two looping usages of `alloca` that could lead to smashed stacks. This may come at a very small cost to latency in some cases, but it helps with program stability, as **any** errors or issues with `alloca` usage causes UB/stack overflows. When used in a loop it is incredibly easy to smash the stack, so it was identified as a `high` security issue. Additionally, usage of `alloca` thwarts inlining, as it is never safe for the compiler to inline `alloca` containing functions. So, in some cases, rather than an increase in latency, the compiler may now be able to provide a decrease due to increased ability to inline functions.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>