### PR TITLE
Fix memory leak from `alloca` fix

### DIFF
--- a/src/AudioIO.cpp
+++ b/src/AudioIO.cpp
@@ -464,6 +464,7 @@ time warp info and AudioIOListener and whether the playback is looped.
 #include "DBConnection.h"
 #include "ProjectFileIO.h"
 #include "WaveTrack.h"
+#include "AudioIOBufferHelper.h"
 
 #include "effects/RealtimeEffectManager.h"
 #include "prefs/QualitySettings.h"
@@ -3843,14 +3844,10 @@ bool AudioIoCallback::FillOutputBuffers(
    }
 
    // ------ MEMORY ALLOCATION ----------------------
-   // These are small structures.
-   auto chans = new WaveTrack * [numPlaybackChannels];
-   auto tempBufs = new float* [numPlaybackChannels];
+   std::shared_ptr<AudioIOBufferHelper> bufHelper = std::make_shared<AudioIOBufferHelper>(numPlaybackChannels, framesPerBuffer);
+   auto chans = bufHelper.get()->chans;
+   auto tempBufs = bufHelper.get()->tempBufs;
 
-   // And these are larger structures....
-   for (unsigned int c = 0; c < numPlaybackChannels; c++) {
-       tempBufs[c] = new float[framesPerBuffer];
-   }
    // ------ End of MEMORY ALLOCATION ---------------
 
    auto & em = RealtimeEffectManager::Get();
@@ -4002,8 +3999,6 @@ bool AudioIoCallback::FillOutputBuffers(
    if (outputMeterFloats != outputFloats)
       ClampBuffer( outputMeterFloats, framesPerBuffer*numPlaybackChannels );
 
-   delete[] chans;
-   delete[] tempBufs;
    return false;
 }
 

--- a/src/AudioIO.h
+++ b/src/AudioIO.h
@@ -580,8 +580,7 @@ protected:
    PlaybackSchedule mPlaybackSchedule;
 };
 
-class AUDACITY_DLL_API AudioIO final
-   : public AudioIoCallback
+class AUDACITY_DLL_API AudioIO final : public AudioIoCallback
 {
 
    AudioIO();

--- a/src/AudioIOBufferHelper.h
+++ b/src/AudioIOBufferHelper.h
@@ -1,0 +1,42 @@
+#ifndef AUDIOIO_BUFFER_HELPER_H
+#define AUDIOIO_BUFFER_HELPER_H
+
+#include "AudioIO.h"
+#include "../libraries/lib-utility/MemoryX.h"
+
+class AudioIOBufferHelper
+{
+
+    private:
+
+        unsigned int numPlaybackChannels;
+        unsigned long framesPerBuffer;
+
+    public:
+        WaveTrack** chans;
+        float** tempBufs;
+
+        AudioIOBufferHelper(const unsigned int numPlaybackChannels, const unsigned long framesPerBuffer) {
+            this->numPlaybackChannels = numPlaybackChannels;
+            this->framesPerBuffer = framesPerBuffer;
+
+            this->chans = safenew WaveTrack * [numPlaybackChannels];
+            this->tempBufs = safenew float* [numPlaybackChannels];
+
+            for (unsigned int c = 0; c < numPlaybackChannels; c++) {
+                tempBufs[c] = safenew float[framesPerBuffer];
+            }
+        }
+
+        ~AudioIOBufferHelper() {
+            for (unsigned int c = 0; c < numPlaybackChannels; c++) {
+                delete[] tempBufs[c];
+            }
+
+            delete[] tempBufs;
+
+            delete[] chans;
+        }
+};
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -100,6 +100,7 @@ list( APPEND SOURCES
       AudioIO.h
       AudioIOBase.cpp
       AudioIOBase.h
+      AudioIOBufferHelper.h
       AudioIOListener.h
       AutoRecoveryDialog.cpp
       AutoRecoveryDialog.h


### PR DESCRIPTION
Rework `alloca` fix to use new helper class for buffer allocations.
Add missing `delete[]` for cleanup of the temporary playback buffer.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>
Reference-to: https://github.com/tenacityteam/tenacity/issues/416
Reference-to: https://github.com/tenacityteam/tenacity/pull/412
Helped-by: Paul Licameli

Resolves: https://github.com/tenacityteam/tenacity/issues/416

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>