### PR TITLE
Improve changes to `ProjectSerializer.cpp`

### DIFF
--- a/src/ProjectSerializer.cpp
+++ b/src/ProjectSerializer.cpp
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <mutex>
 #include <wx/ustring.h>
+#include <cstring>
 
 ///
 /// ProjectSerializer class


### PR DESCRIPTION
Remove pointless addition of null-terminator bytes.
Replace `static_cast` usage with `memcpy` for aliasing reasons.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>
Reference-to: https://github.com/tenacityteam/tenacity/pull/422
Helped-by: nyanpasu64

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>