### PR TITLE
Fixes for building with de-vendored upstream PortAudio

### DIFF
--- a/src/AudioIOBase.cpp
+++ b/src/AudioIOBase.cpp
@@ -21,6 +21,8 @@ Paul Licameli split from AudioIO.cpp
 #include "Prefs.h"
 #include "widgets/MeterPanelBase.h"
 
+#include <portaudio.h>
+
 #if USE_PORTMIXER
 #include "portmixer.h"
 #endif

--- a/src/Experimental.cmake
+++ b/src/Experimental.cmake
@@ -118,7 +118,7 @@ set( EXPERIMENTAL_OPTIONS_LIST
    # RBD, 1 Sep 2008
    # Enables MIDI Output of NoteTrack (MIDI) data during playback
    # USE_MIDI must be defined in order for MIDI_OUT to work
-   MIDI_OUT
+   #MIDI_OUT
 
    # JKC, 17 Aug 2017
    # Enables the MIDI note stretching feature, which currently


### PR DESCRIPTION
Small changes split from #228 for building with upstream PortAudio 

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>