### PR TITLE
Replace references to topdir and libsrc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,10 +35,6 @@ if( "${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}" )
    )
 endif()
 
-# Just a couple of convenience variables
-set( topdir "${CMAKE_SOURCE_DIR}" )
-set( libsrc "${topdir}/lib-src" )
-
 # Default build type is Debug
 if( NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES )
    set( CMAKE_BUILD_TYPE "Debug" )

--- a/cmake-proxies/cmake-modules/AudacityFunctions.cmake
+++ b/cmake-proxies/cmake-modules/AudacityFunctions.cmake
@@ -586,7 +586,7 @@ function( addlib dir name symbol required check )
 
    # Define target's name and it's source directory
    set( TARGET ${dir} )
-   set( TARGET_ROOT ${libsrc}/${dir} )
+   set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/lib-src/${dir} )
 
    # Define the option name
    set( use ${_OPT}use_${name} )

--- a/help/CMakeLists.txt
+++ b/help/CMakeLists.txt
@@ -1,5 +1,5 @@
 set( TARGET manual )
-set( TARGET_ROOT ${topdir}/manual )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/manual )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 
@@ -13,7 +13,7 @@ endif()
 set( host "alphamanual.audacityteam.org" )
 set( src "https://${host}/man" )
 set( dst "${_DEST}/help/manual" )
-set( script_dir "${topdir}/scripts/mw2html_audacity" )
+set( script_dir "${CMAKE_SOURCE_DIR}/scripts/mw2html_audacity" )
 set( script "mw2html.py" )
 set( out_dir "${_INTDIR}" )
 set( out "${out_dir}/${host}/index.html" )

--- a/images/CMakeLists.txt
+++ b/images/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set( TARGET images )
-set( TARGET_ROOT ${topdir}/images )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/images )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 

--- a/locale/CMakeLists.txt
+++ b/locale/CMakeLists.txt
@@ -1,5 +1,5 @@
 set( TARGET locale )
-set( TARGET_ROOT ${topdir}/locale )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/locale )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 

--- a/nyquist/CMakeLists.txt
+++ b/nyquist/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set( TARGET nyquist )
-set( TARGET_ROOT ${topdir}/nyquist )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/nyquist )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 
@@ -61,7 +61,7 @@ foreach( source ${RUNTIME} )
    # Fix this when reorganizing the Nyquist sources
    if( source STREQUAL "system.lsp" )
       if( CMAKE_SYSTEM_NAME MATCHES "Windows" )
-         set( src "${libsrc}/libnyquist/nyquist/sys/win/msvc/system.lsp" )
+         set( src "${CMAKE_SOURCE_DIR}/lib-src/libnyquist/nyquist/sys/win/msvc/system.lsp" )
       endif()
    endif()
 

--- a/plug-ins/CMakeLists.txt
+++ b/plug-ins/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set( TARGET plug-ins )
-set( TARGET_ROOT ${topdir}/plug-ins )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/plug-ins )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set( TARGET minsrc )
-set( TARGET_ROOT ${topdir} )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR} )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 set( TARGET Tenacity )
-set( TARGET_ROOT ${topdir}/src )
+set( TARGET_ROOT ${CMAKE_SOURCE_DIR}/src )
 
 message( STATUS "========== Configuring ${TARGET} ==========" )
 
@@ -25,7 +25,7 @@ if( GIT_FOUND )
                           -D "_PRVDIR=${_PRVDIR}"
                           -P "${AUDACITY_MODULE_PATH}/Version.cmake"
       WORKING_DIRECTORY
-         ${topdir}
+         ${CMAKE_SOURCE_DIR}
    )
 
    add_dependencies( ${TARGET} version )
@@ -1014,7 +1014,7 @@ list( APPEND HEADERS
 list( APPEND INCLUDES
    PUBLIC
       ${_PRVDIR}
-      ${topdir}/include
+      ${CMAKE_SOURCE_DIR}/include
       ${TARGET_ROOT}
 )
 
@@ -1387,11 +1387,11 @@ else()
                FILES_MATCHING PATTERN "*.so*" )
       install( FILES "${_INTDIR}/tenacity.desktop"
                DESTINATION "${_DATADIR}/applications" )
-      install( FILES "${topdir}/LICENSE.txt" "${topdir}/README.md"
+      install( FILES "${CMAKE_SOURCE_DIR}/LICENSE.txt" "${CMAKE_SOURCE_DIR}/README.md"
                DESTINATION "${_DATADIR}/doc/${AUDACITY_NAME}" )
       install( FILES "${_SRCDIR}/tenacity.xml"
                DESTINATION "${_DATADIR}/mime/packages" )
-      install( FILES "${topdir}/presets/EQDefaultCurves.xml"
+      install( FILES "${CMAKE_SOURCE_DIR}/presets/EQDefaultCurves.xml"
                DESTINATION "${_PKGDATA}" )
       install( PROGRAMS "${PROJECT_SOURCE_DIR}/linux/tenacity.sh"
                DESTINATION "."


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/pull/396#discussion_r680357277 (not an issue)

`topdir` and `libsrc` are confusing, seldom used variable names, which aren't any more convenient than the ones they're trying to replace.

I've not touched the `lib-src/` directory, because it seems like `topdir` is being used differently there.
<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>