### PR TITLE
CMake: do not use precompiled headers with sccache

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1346,7 +1346,7 @@ target_link_options( ${TARGET} PRIVATE ${LDFLAGS} )
 target_link_libraries( ${TARGET} ${LIBRARIES} )
 target_link_libraries( ${TARGET} PUBLIC ${AUDACITY_LIBRARIES} )
 
-if( CMAKE_VERSION VERSION_GREATER_EQUAL "3.16" AND NOT CCACHE_PROGRAM )
+if( CMAKE_VERSION VERSION_GREATER_EQUAL "3.16" AND NOT CCACHE_PROGRAM AND NOT SCCACHE_PROGRAM )
    if( ${_OPT}use_pch )
       message( STATUS "Using precompiled headers" )
       target_precompile_headers( ${TARGET} PRIVATE


### PR DESCRIPTION
Signed-off-by: Be <be@mixxx.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

If this is skipped for ccache, it should be for sccache as well.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>