### PR TITLE
Fix build without `USE_MIDI`

### DIFF
--- a/src/tracks/playabletrack/notetrack/ui/NoteTrackAffordanceControls.cpp
+++ b/src/tracks/playabletrack/notetrack/ui/NoteTrackAffordanceControls.cpp
@@ -8,6 +8,8 @@
 
  **********************************************************************/
 
+#ifdef USE_MIDI
+
 #include "NoteTrackAffordanceControls.h"
 
 #include <wx/dc.h>
@@ -91,3 +93,4 @@ bool NoteTrackAffordanceControls::IsSelected() const
     }
     return false;
 }
+#endif // USE_MIDI


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves:

```
..\src\tracks\playabletrack\notetrack\ui\NoteTrackAffordanceControls.cpp(43): error C2027: use of undefined type 'NoteTrack'
D:\a\tenacity\tenacity\src\Track.h(41): note: see declaration of 'NoteTrack'
..\src\tracks\playabletrack\notetrack\ui\NoteTrackAffordanceControls.cpp(43): error C2039: 'GetOffset': is not a member of 'std::shared_ptr<const NoteTrack>'
```

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>