### PR TITLE
Use Tenacity.Project in AudacityApp.cpp

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -2237,14 +2237,14 @@ void AudacityApp::AssociateFileTypes() {
         }
 
         if (!root_key.empty()) {
-            associateFileTypes = wxT("Audacity.Project"); // Finally set value for the key
+            associateFileTypes = wxT("Tenacity.Project"); // Finally set value for the key
         }
 
         return root_key;
     };
 
     // Check for legacy and UP types
-    if (IsDefined(wxT(".aup3")) && IsDefined(wxT(".aup")) && IsDefined(wxT("Audacity.Project"))) {
+    if (IsDefined(wxT(".aup3")) && IsDefined(wxT(".aup")) && IsDefined(wxT("Tenacity.Project"))) {
         // Already defined, so bail
         return;
     }
@@ -2276,25 +2276,25 @@ void AudacityApp::AssociateFileTypes() {
     } else {
         DefineType(wxT(".aup"));
 
-        associateFileTypes = wxT("Audacity.Project"); // Finally set value for .AUP key
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project"));
+        associateFileTypes = wxT("Tenacity.Project"); // Finally set value for .AUP key
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
             associateFileTypes = wxT("Audacity Project File");
         }
 
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell"));
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
             associateFileTypes = wxT("");
         }
 
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell\\open"));
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell\\open"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
         }
 
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell\\open\\command"));
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell\\open\\command"));
         wxString tmpRegAudPath;
         if (associateFileTypes.Exists()) {
             tmpRegAudPath = associateFileTypes.QueryDefaultValue().Lower();
@@ -2310,19 +2310,19 @@ void AudacityApp::AssociateFileTypes() {
         // These can be use later to support more startup messages
         // like maybe "Import into existing project" or some such.
         // Leaving here for an example...
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell\\open\\ddeexec"));
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell\\open\\ddeexec"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
             associateFileTypes = wxT("%1");
         }
 
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell\\open\\ddeexec\\Application"));
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell\\open\\ddeexec\\Application"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
             associateFileTypes = IPC_APPL;
         }
 
-        associateFileTypes.SetName(root_key + wxT("Audacity.Project\\shell\\open\\ddeexec\\Topic"));
+        associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell\\open\\ddeexec\\Topic"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
             associateFileTypes = IPC_TOPIC;


### PR DESCRIPTION
Signed-off-by: Sol Fisher Romanoff <sol@solfisher.com>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/333

`src/AudacityApp.cpp` now uses `Tenacity.Project` instead of `Audacity.Project`. As far as I can see this doesn't create any problems with project importing/exporting to Audacity.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>