### PR TITLE
Use git describe in About Dialog

### DIFF
--- a/cmake-proxies/cmake-modules/Version.cmake
+++ b/cmake-proxies/cmake-modules/Version.cmake
@@ -4,7 +4,7 @@
 
 execute_process(
    COMMAND
-      ${GIT} show -s "--format=#define REV_LONG \"%H\"%n#define REV_TIME \"%cd\"%n" --no-notes --no-show-signature
+      ${GIT} show -s "--format=#define REV_LONG \"%H\"%n#define GIT_DESCRIBE \"${GIT_DESCRIBE}\"%n" --no-notes --no-show-signature
    OUTPUT_FILE
       ${_PRVDIR}/RevisionIdent.h.in
    OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -176,7 +176,7 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
         << XO("The Build")
         << wxT("</h3>\n<table>"); // start build info table
 
-    AddBuildInfoRow(&informationStr, XO("Commit Id:"), BuildInfo::getRevisionIdentifier());
+    AddBuildInfoRow(&informationStr, XO("Version:"), BuildInfo::getRevisionIdentifier());
     AddBuildInfoRow(&informationStr, XO("Build type:"), BuildInfo::getBuildType());
     AddBuildInfoRow(&informationStr, XO("Compiler:"), BuildInfo::getCompilerVersionString());
 
@@ -862,15 +862,15 @@ void AboutDialog::GenerateTenacityPageDescription(wxTextOutputStream& tos) {
     #undef _
     #define _(s) wxGetTranslation((s))
         << wxT("<h3>DarkTenacity ")
-        << wxString(AUDACITY_VERSION_STRING)
+        << wxString(GIT_DESCRIBE)
         << wxT("</h3>")
         << wxT("Customised version of the free, open source, cross-platform audio recorder and editor Tenacity.")
 
     #else
         << XO("<h3>")
         << ProgramName
-        // << wxT(" ")
-        // << wxString(AUDACITY_VERSION_STRING)
+        << wxT(" ")
+        << wxString(GIT_DESCRIBE)
         << wxT("</h3>")
         /* i18n-hint: The program's name substitutes for %s */
         << XO("Free, open source, cross-platform audio recorder and editor.")

--- a/src/BuildInfo.h
+++ b/src/BuildInfo.h
@@ -17,14 +17,14 @@
 
 #include <Internat.h>
 
-// RevisionIdent contains the REV_TIME and REV_LONG defines from git commit information
+// RevisionIdent contains the GIT_DESCRIBE and REV_LONG defines from git commit information
 #include "RevisionIdent.h"
 
 // This define replaces the original that modified the macro in wxwidgets
 #define CUSTOM_wxMAKE_VERSION_DOT_STRING_T(x, y, z) wxSTRINGIZE_T(x) wxT(".") wxSTRINGIZE_T(y) wxT(".") wxSTRINGIZE_T(z) wxT("(Tenacity)")
 
 class BuildInfo {
-    
+
 public:
       enum class CompilerType { MSVC, MinGW, GCC, Clang, Unknown };
 
@@ -88,26 +88,12 @@ public:
         };
 
         static const inline wxString getRevisionIdentifier(){
-        
             static wxString NoRevisionText = XO("No revision identifier was provided").Translation();
 
             #ifdef REV_LONG
-                return wxString( "[[https://github.com/tenacityteam/tenacity/commit/" ) + REV_LONG + "|" + wxString( REV_LONG ).Left(6) + "]] of " +  getRevisionDateTime();
+                return wxString("[[https://github.com/tenacityteam/tenacity/commit/") + REV_LONG + "|" + wxString(GIT_DESCRIBE) + "]]";
             #else
                 return NoRevisionText;
-            #endif
-        }
-
-        static const inline wxString getRevisionDateTime(){
-
-            
-            //This needs to be outside the #ifdef or it won't end up in the POT file consistently
-            static wxString NoDateTimeText = XO("Unknown date and time").Translation();
-
-            #ifdef REV_TIME
-                return wxString(REV_TIME);
-            #else
-                return NoDateTimeText;
             #endif
         }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ if( GIT_FOUND )
       version
       COMMAND
          ${CMAKE_COMMAND} -D GIT="${GIT_EXECUTABLE}"
+                          -D GIT_DESCRIBE="${GIT_DESCRIBE}"
                           -D "_PRVDIR=${_PRVDIR}"
                           -P "${AUDACITY_MODULE_PATH}/Version.cmake"
       WORKING_DIRECTORY


### PR DESCRIPTION
Resolves: #460

Use AUDACITY_VERSION_STRING to be consistent with other references using
git describe, like AudacityApp.cpp CLI arg -v

Signed-off-by: Humberto Rocha <humrochagf@gmail.com>
