### PR TITLE
Change uncaught_exception to uncaught_exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ cmake_policy( SET CMP0075 NEW )
 
 # Definitions that must happen before the project() command
 if( APPLE )
-   set( MIN_MACOS_VERSION 10.9 )
+   set( MIN_MACOS_VERSION 10.12 )
    set( TARGET_MACOS_VERSION 10.13 )
    # Generate schema files
    set( CMAKE_XCODE_GENERATE_SCHEME ON )

--- a/src/AudacityException.h
+++ b/src/AudacityException.h
@@ -168,10 +168,10 @@ inline SimpleGuard< void > MakeSimpleGuard() { return {}; }
 
 /*!
   Executes a given function (typically a lamba), in any thread.
- 
+
   If there is any exception, can invoke another given function as handler, which may rethrow that or
   another exception, but usually just returns the value for the GuardedCall.
- 
+
   If AudacityException is handled, then it queues up a delayed handler action for execution later in
   the event loop at idle time, on the main thread; typically this informs the user of the error.
 
@@ -211,7 +211,7 @@ R GuardedCall(
          // At this point, e is the "current" exception, but not "uncaught"
          // unless it was rethrown by handler.  handler might also throw some
          // other exception object.
-         if (!std::uncaught_exception()) {
+         if (std::uncaught_exceptions() == 0) {
             auto pException = std::current_exception(); // This points to e
             wxTheApp->CallAfter( [=] { // capture pException by value
                try { std::rethrow_exception(pException); }

--- a/src/import/ImportAUP.cpp
+++ b/src/import/ImportAUP.cpp
@@ -74,7 +74,7 @@ public:
    ~AUPImportPlugin();
 
    wxString GetPluginStringID() override;
-   
+
    TranslatableString GetPluginFormatDescription() override;
 
    ImportHandle Open(const FilePath &fileName,
@@ -235,7 +235,7 @@ wxString AUPImportPlugin::GetPluginStringID()
 {
    return wxT("legacyaup");
 }
-   
+
 TranslatableString AUPImportPlugin::GetPluginFormatDescription()
 {
    return DESC;
@@ -478,7 +478,7 @@ bool AUPImportFileHandle::Open()
       char buf[256];
 
       int numRead = ff.Read(buf, sizeof(buf));
-      
+
       ff.Close();
 
       buf[sizeof(buf) - 1] = '\0';
@@ -531,7 +531,7 @@ void AUPImportFileHandle::HandleXMLEndTag(const wxChar *tag)
    {
       node.handler->HandleXMLEndTag(tag);
    }
-   
+
    mHandlers.pop_back();
 
    if (mHandlers.size())
@@ -923,7 +923,7 @@ bool AUPImportFileHandle::HandleTags(XMLTagHandler *&handler)
       {
          break;
       }
-      
+
       // Ignore empty tags
       if (!*value)
       {
@@ -1199,7 +1199,7 @@ bool AUPImportFileHandle::HandleSimpleBlockFile(XMLTagHandler *&handler)
 {
    FilePath filename;
    size_t len = 0;
-   
+
    while (*mAttrs)
    {
       const wxChar *attr =  *mAttrs++;
@@ -1251,7 +1251,7 @@ bool AUPImportFileHandle::HandleSilentBlockFile(XMLTagHandler *&handler)
 {
    FilePath filename;
    size_t len = 0;
-   
+
    while (*mAttrs)
    {
       const wxChar *attr =  *mAttrs++;
@@ -1527,7 +1527,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
 
          // If we are unwinding for an exception, don't do another
          // potentially throwing operation
-         if (!std::uncaught_exception())
+         if (std::uncaught_exceptions() == 0)
             // If this does throw, let that propagate, don't guard the call
             AddSilence(len);
       }
@@ -1572,7 +1572,7 @@ bool AUPImportFileHandle::AddSamples(const FilePath &blockFilename,
    samplePtr bufptr = buffer.ptr();
 
    size_t framesRead = 0;
-   
+
    // These cases preserve the logic formerly in BlockFile.cpp,
    // which was deleted at commit 98d1468.
    if (channels == 1 && format == int16Sample && sf_subtype_is_integer(info.format))


### PR DESCRIPTION
std::uncaught_exception() was deprecated ages ago in favour of
std::uncaught_exceptions().

Signed-off-by: Sol Fisher Romanoff <sol@solfisher.com>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/432

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>