### PR TITLE
Detect Audacity.Project files

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -2244,7 +2244,10 @@ void AudacityApp::AssociateFileTypes() {
     };
 
     // Check for legacy and UP types
-    if (IsDefined(wxT(".aup3")) && IsDefined(wxT(".aup")) && IsDefined(wxT("Tenacity.Project"))) {
+    if (IsDefined(wxT(".aup3"))
+        && IsDefined(wxT(".aup"))
+        && IsDefined(wxT("Tenacity.Project"))
+        && IsDefined(wxT("Audacity.Project"))) {
         // Already defined, so bail
         return;
     }


### PR DESCRIPTION
As we replaced references to "Audacity.Project" files in order to distinguish
between our own project files ("Tenacity.Project") and Audacity's project
files, we unnecessarily removed code that would detect some Audacity project
files and just kept ours instead. It does not make too much of a difference,
because the file extensions (which the conditions also look for) were left
intact.

I also took the opportunity to improve the appearance of the conditions
by breaking them between multiple lines.

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>