### PR TITLE
Fixed Audacity.Project regression, added own branding

### DIFF
--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -2246,8 +2246,7 @@ void AudacityApp::AssociateFileTypes() {
     // Check for legacy and UP types
     if (IsDefined(wxT(".aup3"))
         && IsDefined(wxT(".aup"))
-        && IsDefined(wxT("Tenacity.Project"))
-        && IsDefined(wxT("Audacity.Project"))) {
+        && IsDefined(wxT("Tenacity.Project"))) {
         // Already defined, so bail
         return;
     }

--- a/src/AudacityApp.cpp
+++ b/src/AudacityApp.cpp
@@ -2282,7 +2282,7 @@ void AudacityApp::AssociateFileTypes() {
         associateFileTypes.SetName(root_key + wxT("Tenacity.Project"));
         if (!associateFileTypes.Exists()) {
             associateFileTypes.Create(true);
-            associateFileTypes = wxT("Audacity Project File");
+            associateFileTypes = wxT("Tenacity Project File");
         }
 
         associateFileTypes.SetName(root_key + wxT("Tenacity.Project\\shell"));


### PR DESCRIPTION
What I tried to do here, as well as the alternative fixes I considered,
is way too large to explain. Long story short, I wanted to initially check
whether Tenacity.Project OR Audacity.Project was defined, but a typo as I was
formatting the change led to a logic error.

However, even if I did what I wanted to do, that would mean that we'd "lose"
our opportunity to ask the user whether they want to use Tenacity instead of
other programs. The Audacity developers basically already fixed the problem
that I was trying to fix, and the solution was right in front of us.

Apart from that, I also fixed a string so that the associated filetypes show
up as Tenacity Project Files. The user chose to associate them with Tenacity
anyway, so it makes perfect sense.

---

Note to reviewers: Since the latest commit caused a pretty big issue as a result of proceeding way too fast with merging without properly examining the consequences, it may be a good idea to just do the "push this to master ASAP" thing again if possible. Excuse the long commit message, but I believe that documenting the mindset behind certain decisions is important.

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>