### PR TITLE
Make `repeat_hdiutil.sh` kill icon agent

### DIFF
--- a/scripts/ci/macos/repeat_hdiutil.sh
+++ b/scripts/ci/macos/repeat_hdiutil.sh
@@ -16,6 +16,8 @@ until /usr/bin/hdiutil "$@"; do
         echo "CPack failed despite retry attempts!"
         exit 1
    else
+        echo "Attempting to kill com.apple.IconServicesAgent"
+        killall -KILL com.apple.IconServicesAgent
         echo "Trying CPack hdiutil call again. Retry attempt #$counter"
         ((counter++))
    fi


### PR DESCRIPTION
Now on retries the script will issue a `killall` to the `com.apple.IconServicesAgent` service.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

https://www.youtube.com/watch?v=Fow7iUaKrq4

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->
<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>