### PR TITLE
BUILDING.md: Remove PortSMF from Debian section

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -23,7 +23,7 @@ not required. CMake will automatically use ccache if it is installed.
 To install Tenacity's dependencies, run:
 
 ```
-sudo apt-get install build-essential libavcodec-dev libavformat-dev libavutil-dev libflac++-dev libglib2.0-dev libgtk-3-dev libid3tag0-dev libjack-dev liblilv-dev libmad0-dev libmp3lame-dev libogg-dev libpng-dev portaudio19-dev libportmidi-dev libportsmf-dev libserd-dev libsndfile1-dev libsord-dev libsoundtouch-dev libsoxr-dev libsuil-dev libtwolame-dev vamp-plugin-sdk libvorbis-dev lv2-dev zlib1g-dev cmake ninja-build libjpeg-dev libtiff-dev liblzma-dev libsqlite3-dev
+sudo apt-get install build-essential libavcodec-dev libavformat-dev libavutil-dev libflac++-dev libglib2.0-dev libgtk-3-dev libid3tag0-dev libjack-dev liblilv-dev libmad0-dev libmp3lame-dev libogg-dev libpng-dev portaudio19-dev libportmidi-dev libserd-dev libsndfile1-dev libsord-dev libsoundtouch-dev libsoxr-dev libsuil-dev libtwolame-dev vamp-plugin-sdk libvorbis-dev lv2-dev zlib1g-dev cmake ninja-build libjpeg-dev libtiff-dev liblzma-dev libsqlite3-dev
 ```
 
 wxWidgets 3.1 is required but not packaged in Debian or Ubuntu. Refer


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/499

Moved from #511 since branch renaming.
Solves build problems on Debian/Ubuntu based distributions where broken/outdated PortSMF libraries (libportsmf-dev) were used by avoiding build error in later stage, as described in comments of #499. Forked [PortSMF](https://github.com/tenacityteam/portsmf) where bugs causing such errors were fixed should be used instead if needed. If another copy of PortSMF is installed globally, it's preferred to install it to another location and use `-DCMAKE_PREFIX_PATH=/path/to/alternate/prefix` where alternate versions are installed.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>