### PR TITLE
Implement Nuget Caching

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  workflow_dispatch:
 
 defaults:
   run:
@@ -73,6 +74,7 @@ jobs:
 
       VCPKG_DISABLE_METRICS: true
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.config.vcpkg_triplet }}
+      VCPKG_BINARY_SOURCES: "clear;default,readwrite;nuget,https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget,readwrite"
 
       # Windows codesigning
       # This variables will be used by all the steps
@@ -88,13 +90,31 @@ jobs:
       with:
         submodules: true
 
+
+    - name: Install Nuget
+      uses: nuget/setup-nuget@v1
+      with:
+        # Nuget versions needs to be the same version that vcpkg expects
+        # So update them in parallel
+        nuget-version: 5.10.0
+
+    - name: Authenticate CI to Artifactory
+      if:  github.event_name == 'push' && github.repository_owner == 'tenacityteam'
+      run: |
+        nuget sources Add -Name Artifactory -Source https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget -username ${JFROG_ARTIFACTORY_NUGET_USER} -password ${JFROG_ARTIFACTORY_NUGET_PASS} -ForceEnglishOutput -NonInteractive
+        nuget setapikey ${JFROG_ARTIFACTORY_NUGET_USER}:${JFROG_ARTIFACTORY_NUGET_TOKEN} -Source Artifactory -ForceEnglishOutput -NonInteractive
+      env:
+        JFROG_ARTIFACTORY_NUGET_USER: ${{secrets.JFROG_ARTIFACTORY_NUGET_USER}}
+        JFROG_ARTIFACTORY_NUGET_PASS: ${{secrets.JFROG_ARTIFACTORY_NUGET_PASS}}
+        JFROG_ARTIFACTORY_NUGET_TOKEN: ${{secrets.JFROG_ARTIFACTORY_NUGET_TOKEN}}
+
     - name: Install dependencies
       run: |
         exec bash "scripts/ci/dependencies.sh"
 
     - name: Install Apple codesigning certificates
       uses: apple-actions/import-codesign-certs@v1
-      if: startswith( matrix.config.os, 'macos' ) && github.event_name == 'push' && github.repository_owner == 'audacity'
+      if: startswith( matrix.config.os, 'macos' ) && github.event_name == 'push' && github.repository_owner == 'tenacityteam'
       with:
         p12-file-base64: ${{ secrets.APPLE_CERTIFICATE }}
         p12-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -99,7 +99,7 @@ jobs:
         nuget-version: 5.10.0
 
     - name: Authenticate CI to Artifactory
-      if:  github.event_name == 'push' && github.repository_owner == 'tenacityteam'
+      if: github.event_name == 'push' && github.repository_owner == 'tenacityteam'
       run: |
         nuget sources Add -Name Artifactory -Source https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget -username ${JFROG_ARTIFACTORY_NUGET_USER} -password ${JFROG_ARTIFACTORY_NUGET_PASS} -ForceEnglishOutput -NonInteractive
         nuget setapikey ${JFROG_ARTIFACTORY_NUGET_USER}:${JFROG_ARTIFACTORY_NUGET_TOKEN} -Source Artifactory -ForceEnglishOutput -NonInteractive
@@ -236,8 +236,9 @@ jobs:
         if-no-files-found: error
 
     - name: Upload artifact of vcpkg build logs
-      if: always()
       uses: actions/upload-artifact@v2
+      if: always()
       with:
         name: vcpkg-logs-${{ runner.os }}
         path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
+        if-no-files-found: ignore

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ endif()
 
 if(VCPKG)
   set(ENV{VCPKG_DISABLE_METRICS} true)
+  if(NOT DEFINED ENV{VCPKG_BINARY_SOURCES})
+    set(ENV{VCPKG_BINARY_SOURCES} "clear;default,readwrite;nuget,https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget,read")
+  endif()
+  set(ENV{VCPKG_FEATURE_FLAGS} "-compilertracking,manifests,registries,versions")
 
   if(VCPKG_ROOT)
     message(STATUS "Using dependencies from vcpkg repository at ${VCPKG_ROOT}")


### PR DESCRIPTION
Add support for binary caching for vcpkg using nuget to access the [tenacityteam Artifactory instance](https://tenacityteam.jfrog.io). @emabrey is administrating the Artifactory instance and is able to provide user accounts with appropriate permissions to anyone who needs one (though honestly, that is basically nobody, since the Artifactory instance supports anonymous reads, so you don't need to have an authentication source setup to use it from within CMake, it should just work).

This setup:

* Only writes to the Artifactory instance using a non-administrator account which can be revoked easily should it somehow be compromised
* Only writes cache artifacts to Artifactory on an actual push event (which is currently only triggered for the master branch)
* If authentication fails or we are on a pull request or a fork, the cache can still be used to read the binaries, but not write, and the fallback is graceful
* Utilizes new Github repo secrets to provide authentication
* Also fixes a minor issue with MacOS signing where it would never run because it was looking for the "audacity" repo owner

Please note that even though it claims to enable "readwrite" to the Artifactory instance globally without reservation, without the authentication tokens nothing actually happens other than the "read" scenario which is the default anyway.

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>