### PR TITLE
ProjectFileIO: Check for SQLITE_ENABLE_DBPAGE_VTAB option

### DIFF
--- a/src/ProjectFileIO.cpp
+++ b/src/ProjectFileIO.cpp
@@ -2389,6 +2389,12 @@ int64_t ProjectFileIO::GetDiskUsage(DBConnection &conn, SampleBlockID blockid /*
    int64_t right = 0;
    int rc;
 
+   // "sqlite_dbpage" is a compile-time defined option
+   if(!sqlite3_compileoption_used("SQLITE_ENABLE_DBPAGE_VTAB"))
+   {
+       return 0;
+   }
+
    // Get the rootpage for the sampleblocks table.
    sqlite3_stmt *stmt =
       conn.Prepare(DBConnection::GetRootPage,


### PR DESCRIPTION
Signed-off-by: Leon Marz <main@lmarz.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #564

Add a check to see if SQLite has the virtual table "sqlite_dbpage", which is used to calculate the size of one or all sample blocks.
This change implicitly disables compacting since `ProjectFileIO::ShouldCompact` will always return false if the return value of `ProjectFileIO::GetDiskUsage` is 0. "But that is a sacrifice I am willing to make" - Lord Farquaad

See the issue for more context

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>