### PR TITLE
Fix aarch64 flatpak builds

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -18,8 +18,19 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v3
+    # Emulate to provide ARM support
+    - name: Install deps
+      run: |
+        dnf -y install docker ninja-build
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: arm64
+    - uses: bilelmoussaoui/flatpak-github-actions/flatpak-builder@v4
       with:
         bundle: tenacity.flatpak
         manifest-path: packaging/flatpak/org.tenacity.Tenacity.json
         cache-key: flatpak-builder-${{ github.sha }}
+        arch: ${{ matrix.arch }}


### PR DESCRIPTION
~~The cache key was the same across the matrix, leading to cache collisions. Because GitHub Actions prevents cache collisions by detecting duplicate keys, only one of the build architectures was being cached per run (whichever one accessed the cache storage by key for writes first). This simply adds additional information to the cache key so that the two runs won't collide.~~

It turns out that the better way to fix this was to update to v4 of the flatpak-github-actions. Doing so required that I fix another issue with the ARM builds, which weren't actually being done correctly and needed QEMU/Docker to emulate an ARM platform to get an ARM output.

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

![image](https://user-images.githubusercontent.com/3370875/131563945-4fc7b750-8307-47ff-a8bf-456904a8ba9c.png)


<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>