### PR TITLE
Fix `vamphost-sdk` CMake find module

### DIFF
--- a/.builds/alpine.yml
+++ b/.builds/alpine.yml
@@ -31,5 +31,5 @@ tasks:
       ../configure --with-gtk --disable-xlocale
       make -j2
       sudo make install
-  - configure: cmake -G Ninja -S tenacity -B build
+  - configure: cmake -G Ninja -S tenacity -B build -D USE_VAMP=OFF
   - build: cmake --build build

--- a/cmake-modules/FindVampHostSDK.cmake
+++ b/cmake-modules/FindVampHostSDK.cmake
@@ -49,23 +49,35 @@ find_path(VampHostSDK_INCLUDE_DIR
   DOC "VampHostSDK include directory")
 mark_as_advanced(VampHostSDK_INCLUDE_DIR)
 
-find_library(VampHostSDK_LIBRARY
-  NAMES vamp-hostsdk
+find_library(VampHostSDK_LIBRARY_RELEASE
+  NAMES vamp-hostsdk libvamp-hostsdk
   PATHS ${PC_VampHostSDK_LIBRARY_DIRS}
-  DOC "VampHostSDK library"
+  DOC "VampHostSDK release library"
 )
-mark_as_advanced(VampHostSDK_LIBRARY)
+
+find_library(VampHostSDK_LIBRARY_DEBUG
+  NAMES vamp-hostsdkd libvamp-hostsdkd vamp-hostsdk libvamp-hostsdk
+  PATHS ${PC_VampHostSDK_LIBRARY_DIRS}
+  DOC "VampHostSDK debug library"
+)
 
 include(FindPackageHandleStandardArgs)
+
 find_package_handle_standard_args(
   VampHostSDK
   DEFAULT_MSG
-  VampHostSDK_LIBRARY
+  VampHostSDK_LIBRARY_DEBUG
+  VampHostSDK_INCLUDE_DIR
+)
+
+find_package_handle_standard_args(
+  VampHostSDK
+  DEFAULT_MSG
+  VampHostSDK_LIBRARY_RELEASE
   VampHostSDK_INCLUDE_DIR
 )
 
 if(VampHostSDK_FOUND)
-  set(VampHostSDK_LIBRARIES "${VampHostSDK_LIBRARY}")
   set(VampHostSDK_INCLUDE_DIRS "${VampHostSDK_INCLUDE_DIR}")
   set(VampHostSDK_DEFINITIONS ${PC_VampHostSDK_CFLAGS_OTHER})
 
@@ -73,7 +85,8 @@ if(VampHostSDK_FOUND)
     add_library(VampHostSDK::VampHostSDK UNKNOWN IMPORTED)
     set_target_properties(VampHostSDK::VampHostSDK
       PROPERTIES
-        IMPORTED_LOCATION "${VampHostSDK_LIBRARY}"
+        IMPORTED_LOCATION_DEBUG "${VampHostSDK_LIBRARY_DEBUG}"
+        IMPORTED_LOCATION ${VampHostSDK_LIBRARY_RELEASE}
         INTERFACE_COMPILE_OPTIONS "${PC_VampHostSDK_CFLAGS_OTHER}"
         INTERFACE_INCLUDE_DIRECTORIES "${VampHostSDK_INCLUDE_DIR}"
     )


### PR DESCRIPTION
Resolves: https://github.com/tenacityteam/tenacity/issues/526

Fix for the issue that was blocking vcpkg builds from properly running because of the missing `vamp-hostsdk` and `vamp-hostsdkd` libs.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>