### PR TITLE
Remove crash reporting menu items from the help menu

### DIFF
--- a/src/menus/HelpMenus.cpp
+++ b/src/menus/HelpMenus.cpp
@@ -347,31 +347,6 @@ void OnShowLog( const CommandContext &context )
    }
 }
 
-#ifdef IS_ALPHA
-void OnSegfault(const CommandContext &)
-{
-   unsigned *p = nullptr;
-   *p = 0xDEADBEEF;
-}
-   
-void OnException(const CommandContext &)
-{
-   // Throw an exception that can be caught only as (...)
-   // The intent is to exercise detection of unhandled exceptions by the
-   // crash reporter
-   struct Unique{};
-   throw Unique{};
-}
-   
-void OnAssertion(const CommandContext &)
-{
-   // We don't use assert() much directly, but Breakpad does detect it
-   // This may crash the program only in debug builds
-   // See also wxSetAssertHandler, and wxApp::OnAssertFailure()
-   assert(false);
-}
-#endif
-
 void OnMenuTree(const CommandContext &context)
 {
    auto &project = context.project;
@@ -533,15 +508,6 @@ BaseItemSharedPtr HelpMenu()
       #ifdef IS_ALPHA
             // alpha-only items don't need to internationalize, so use
             // Verbatim for labels
-
-            Command( wxT("RaiseSegfault"), Verbatim("Test segfault report"),
-               FN(OnSegfault), AlwaysEnabledFlag ),
-
-            Command( wxT("ThrowException"), Verbatim("Test exception report"),
-               FN(OnException), AlwaysEnabledFlag ),
-
-            Command( wxT("ViolateAssertion"), Verbatim("Test assertion report"),
-               FN(OnAssertion), AlwaysEnabledFlag ),
 
             // Menu explorer.  Perhaps this should become a macro command
             Command( wxT("MenuTree"), Verbatim("Menu Tree..."),


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/582

This PR tries to undo most of changes made by d28554189de364d786ab7918558db60c2ed07719 by removing the mostly unused crash reporting menu items from the help menu since they do nothing but just cause a crash and do nothing else, also the code related to it can be safely removed as long as it is not being used elsewhere, and so this PR attempts to do that.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>