### PR TITLE
Workaround for git describe command using only using annotated tags for it's output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ set( GIT_DESCRIBE "unknown" )
 
 if( GIT_FOUND )
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --abbrev=7
+    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=7
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_DESCRIBE
     OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: N/A, Might help improving https://github.com/tenacityteam/tenacity/issues/585

This PR includes a workaround for git describe command only using annotated tags for generating it's output. By adding `--tags` to its command line this behavior would be changed to more proper one.
From manual:
> --tags
>       Instead of using only the annotated tags, use any tag found in refs/tags namespace. This option enables matching a lightweight (non-annotated) tag.

On current master (b9ad2747fb9a23b91a4b6f7ff2d3b4f8a910d6c7), with added parameter command output would be `Audacity-3.0.2-707-gb9ad274` otherwise `Audacity-2.4.1-1873-gb9ad274` as shown in build files and output.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>