### PR TITLE
GH Actions: revert to using Ninja CMake generator for all OSes

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -27,51 +27,30 @@ jobs:
           os: ubuntu-20.04
           arch: x86_64
           vcpkg_triplet: x64-linux
-          CMAKE_GENERATOR: Ninja
 
         - name: macOS - Big Sur 11 (Intel) - Ninja
           id: macos-bigsur-1100-intel-x64_osx_1012min-ninja
           os: macos-11
           arch: Intel
           vcpkg_triplet: x64-osx-10.12min
-          CMAKE_GENERATOR: Ninja
 
         - name: macOS - Catalina 10.15 (Intel) - Ninja
           id: macos-catalina-1015-intel-x64_osx_1012min-ninja
           os: macos-10.15
           arch: Intel
           vcpkg_triplet: x64-osx-10.12min
-          CMAKE_GENERATOR: Ninja
-
-        - name: Windows - Server 2019 (amd64) - Visual Studio 2019
-          id: windows-server-2019-amd64-x64_windows-vs2019_x64
-          os: windows-2019
-          arch: amd64
-          vcpkg_triplet: x64-windows
-          CMAKE_GENERATOR: Visual Studio 16 2019
-          CMAKE_GENERATOR_PLATFORM: x64
-
-        - name: Windows - Server 2019 (win32) - Visual Studio 2019
-          id: windows-server-2019-x86-x86_windows-vs2019_win32
-          os: windows-2019
-          arch: x86
-          vcpkg_triplet: x86-windows
-          CMAKE_GENERATOR: Visual Studio 16 2019
-          CMAKE_GENERATOR_PLATFORM: win32
 
         - name: Windows - Server 2019 (amd64) - Ninja
           id: windows-server-2019-amd64-x64_windows-ninja
           os: windows-2019
           arch: amd64
           vcpkg_triplet: x64-windows
-          CMAKE_GENERATOR: Ninja
 
         - name: Windows - Server 2019 (win32) - Ninja
           id: windows-server-2019-x86-x86_windows-ninja
           os: windows-2019
           arch: x86
           vcpkg_triplet: x86-windows
-          CMAKE_GENERATOR: Ninja
 
 
     env:
@@ -81,7 +60,7 @@ jobs:
 
       # CMake settings
       CMAKE_BUILD_TYPE: MinSizeRel
-      CMAKE_GENERATOR: ${{matrix.config.CMAKE_GENERATOR}}
+      CMAKE_GENERATOR: Ninja
       CMAKE_GENERATOR_PLATFORM: ${{matrix.config.CMAKE_GENERATOR_PLATFORM}}
 
       # vcpkg settings


### PR DESCRIPTION
This is consistent with the BUILDING.md documentation.

Doing redundant Windows builds wastes resources. GitHub Actions
gives us 20 concurrent jobs but adding 2 unnecessary jobs to every
push will push us to that limit more often.

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>