### PR TITLE
[POC] use WIX CPack generator for Windows installer

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -80,7 +80,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: 10.12
 
       # CMake settings
-      CMAKE_BUILD_TYPE: MinSizeRel
+      CMAKE_BUILD_TYPE: RelWithDebInfo
       CMAKE_GENERATOR: ${{matrix.config.CMAKE_GENERATOR}}
       CMAKE_GENERATOR_PLATFORM: ${{matrix.config.CMAKE_GENERATOR_PLATFORM}}
 
@@ -268,13 +268,9 @@ jobs:
 
     - name: Package
       run: |
-        if [[ "${{runner.os}}" == "Windows" ]]; then
-          cmake --build build --target innosetup --config ${{ env.CMAKE_BUILD_TYPE }}
-        else
-          cd build
-          cpack -C ${{ env.CMAKE_BUILD_TYPE }} -D CPACK_COMMAND_HDIUTIL=${{ env.CPACK_COMMAND_HDIUTIL }} --verbose
-          rm -r package/_CPack_Packages
-        fi
+        cd build
+        cpack -C ${{ env.CMAKE_BUILD_TYPE }} -D CPACK_COMMAND_HDIUTIL=${{ env.CPACK_COMMAND_HDIUTIL }} --verbose
+        rm -r package/_CPack_Packages
       env:
         # Workaround for CPack hdiutil/ finder service race condition bug
         CPACK_COMMAND_HDIUTIL: ${{ github.workspace }}/scripts/ci/macos/repeat_hdiutil.sh

--- a/cmake-proxies/cmake-modules/Package.cmake
+++ b/cmake-proxies/cmake-modules/Package.cmake
@@ -54,6 +54,8 @@ elseif( CMAKE_SYSTEM_NAME STREQUAL "Darwin" )
       # CPACK_POST_BUILD_SCRIPTS was added in 3.19, but we only need it on macOS
       SET( CPACK_POST_BUILD_SCRIPTS "${CMAKE_SOURCE_DIR}/scripts/build/macOS/DMGSign.cmake" )
    endif()
+elseif(WIN32)
+    set( CPACK_GENERATOR WIX )
 endif()
 
 include(CPack) # do this last


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

This is a quick hack proof of concept to test if we can build smaller installers with WIX than Innosetup. I don't know why Audacity was using Innosetup when CPack can take care of this.

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [N/A] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>