### PR TITLE
Modify Nuget Cache to Github Packages

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -87,12 +87,7 @@ jobs:
       # vcpkg settings
       VCPKG_DISABLE_METRICS: true
       VCPKG_DEFAULT_TRIPLET: ${{ matrix.config.vcpkg_triplet }}
-      VCPKG_BINARY_SOURCES: "clear;default,readwrite;nuget,https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget,readwrite"
-
-      # Artifactory cache settings
-      JFROG_ARTIFACTORY_NUGET_USER: ${{secrets.JFROG_ARTIFACTORY_NUGET_USER}}
-      JFROG_ARTIFACTORY_NUGET_PASS: ${{secrets.JFROG_ARTIFACTORY_NUGET_PASS}}
-      JFROG_ARTIFACTORY_NUGET_TOKEN: ${{secrets.JFROG_ARTIFACTORY_NUGET_TOKEN}}
+      NUGET_PACKAGES: ${{ github.workspace }}/vcpkg/packages/
 
       # Apple codesigning
       APPLE_CODESIGN_IDENTITY: ${{ secrets.APPLE_CODESIGN_IDENTITY }}
@@ -166,11 +161,17 @@ jobs:
       with:
         nuget-version: 5.10.0
 
-    - name: "[On Push] Authenticate CI to Artifactory"
-      if: github.event_name == 'push' && github.repository_owner == 'tenacityteam'
+    - name: "Authenticate CI to Github Packages"
+      if: github.repository_owner == 'tenacityteam'
       run: |
-        nuget sources Add -Name Artifactory -Source https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget -username ${JFROG_ARTIFACTORY_NUGET_USER} -password ${JFROG_ARTIFACTORY_NUGET_PASS} -ForceEnglishOutput -NonInteractive
-        nuget setapikey ${JFROG_ARTIFACTORY_NUGET_USER}:${JFROG_ARTIFACTORY_NUGET_TOKEN} -Source Artifactory -ForceEnglishOutput -NonInteractive
+        rm ./nuget.config
+        nuget sources add -Name tenacityteam_github_auto -Source https://nuget.pkg.github.com/tenacityteam/index.json -Username tenacityteam -Password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText -ForceEnglishOutput -NonInteractive
+        nuget setapikey ${{ secrets.GITHUB_TOKEN }} -Source tenacityteam_github_auto -ForceEnglishOutput -NonInteractive
+        if [[ ${{ github.event_name }} == 'push' ]]; then
+          echo "VCPKG_BINARY_SOURCES=clear;nuget,tenacityteam_github_auto,readwrite;" >> ${GITHUB_ENV}
+        else
+          echo "VCPKG_BINARY_SOURCES=clear;nuget,tenacityteam_github_auto,read;" >> ${GITHUB_ENV}
+        fi
 
     - name: "[Linux] Install dependencies"
       if: runner.os == 'Linux'
@@ -192,6 +193,7 @@ jobs:
         libgtk-3-dev
         libsuil-dev
         gettext
+
     - name: "[MacOS] Install dependencies"
       if: runner.os == 'macOS'
       run: >-
@@ -200,6 +202,7 @@ jobs:
         ccache
         ninja
         nasm
+
     - name: "[Windows] Install dependencies"
       if: runner.os == 'Windows'
       shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if( VCPKG )
   set( ENV{VCPKG_DISABLE_METRICS} true )
 
   if( NOT DEFINED ENV{VCPKG_BINARY_SOURCES} )
-    set( ENV{VCPKG_BINARY_SOURCES} "clear;default,readwrite;nuget,https://tenacityteam.jfrog.io/artifactory/api/nuget/tenacity-nuget,read" )
+    set( ENV{VCPKG_BINARY_SOURCES} "clear;nuget,tenacityteam_github_auto,read;" )
   endif()
 
   set( ENV{VCPKG_FEATURE_FLAGS} "-compilertracking,manifests,registries,versions" )

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+
+    <config>
+        <add key="defaultPushSource" value="https://nuget.pkg.github.com/tenacityteam/index.json" />
+    </config>
+
+    <packageSources>
+        <add key="tenacityteam_github_auto" value="https://nuget.pkg.github.com/tenacityteam/index.json" />
+    </packageSources>
+
+
+    <packageSourceCredentials>
+        <tenacityteam_github_auto>
+            <add key="Username" value="tenacityteamci" />
+            <add key="Password" value="Z2hwX1pkWG9YZnR4RFRWMjBVakFtSUwyTXc5NWtja2hibzBobWlZeg==" />
+        </tenacityteam_github_auto>
+    </packageSourceCredentials>
+
+    <apikeys>
+        <add key="https://nuget.pkg.github.com/tenacityteam/index.json" value="AQAAANCMnd8BFdERjHoAwE/Cl+sBAAAAUqERagW7+Eu+K0Mct8Lx1QAAAAACAAAAAAAQZgAAAAEAACAAAABgLxr6r/iMxsCDAsoK6EMR0pQlfBfLa2ETAzyCYf8eGgAAAAAOgAAAAAIAACAAAAD+yqdTYe/0Sy9Gmwn5sdaXDh1Bb2I7e9MRDX5HnS1mDDAAAAAU2YvFeiD/IhDcj84qHDE2QUcGsiVCRWecyHvUuedqqMxp5fHj65ZsXj5TPpuYafhAAAAAzx0UqJezLSUsHGwGwctzQvrz0CDNdbUHYXyAI/GGh6lbGv0k3yGJTpF9LFoUvOGQz1mvneSE0NHZAjkMGLuMAw==" />
+    </apikeys>
+
+</configuration>


### PR DESCRIPTION
Modify `cmake_build.yml` to populate Github Packages Nuget cache via CI builds
Modify `CMakeLists.txt` to read from Github Packages Nuget cache during builds
Add `nuget.config` to enable nuget cache for contributors without configuration

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>