### PR TITLE
GH Actions: do not cache vcpkg's local cache

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -119,7 +119,6 @@ jobs:
           echo COMPILER_CACHE_PATH=C:\Users\runneradmin\AppData\Local\Mozilla\sccache\cache >> ${GITHUB_ENV}
           echo COMPILER_CACHE=sccache >> ${GITHUB_ENV}
           echo EXE_SUFFIX=.exe >> ${GITHUB_ENV}
-          echo VCPKG_CACHE_PATH=C:\Users\runneradmin\AppData\Local\vcpkg >> ${GITHUB_ENV}
           echo CMAKE_C_COMPILER_LAUNCHER=sccache >> ${GITHUB_ENV}
           echo CMAKE_CXX_COMPILER_LAUNCHER=sccache >> ${GITHUB_ENV}
           if [[ "${{ env.CMAKE_GENERATOR }}" == "Ninja" ]]; then
@@ -131,7 +130,6 @@ jobs:
           echo COMPILER_CACHE_PATH= ~/Library/Caches/ccache >> ${GITHUB_ENV}
           echo COMPILER_CACHE=ccache >> ${GITHUB_ENV}
           echo EXE_SUFFIX= >> ${GITHUB_ENV}
-          echo VCPKG_CACHE_PATH=~/.cache/vcpkg >> ${GITHUB_ENV}
           echo CMAKE_C_COMPILER_LAUNCHER=ccache >> ${GITHUB_ENV}
           echo CMAKE_CXX_COMPILER_LAUNCHER=ccache >> ${GITHUB_ENV}
           if [[ "${{runner.os}}" == "Linux" ]]; then
@@ -214,17 +212,16 @@ jobs:
         iwr -useb get.scoop.sh | iex
         scoop install sccache
 
-    # Cache the vcpkg cache and the vcpkg executable to avoid bootstrapping each time
+    - name: Get Git commit of vcpkg submodule
+      run: echo VCPKG_COMMIT=$(git ls-tree HEAD vcpkg | awk '{print $3}') >> ${GITHUB_ENV}
+
+    # Cache the vcpkg executable to avoid bootstrapping each time
     - name: Setup vcpkg cache
       uses: actions/cache@v2
       with:
-        path: |
-          ${{ github.workspace }}/vcpkg/vcpkg${{ env.EXE_SUFFIX }}
-          ${{ env.VCPKG_CACHE_PATH }}
-        key: ${{ matrix.config.id }}-${{ hashFiles('**/vcpkg.json') }}-${{ env.VCPKG_COMMIT }}-${{ github.run_number }}
+        path: ${{ github.workspace }}/vcpkg/vcpkg${{ env.EXE_SUFFIX }}
+        key: ${{ matrix.config.id }}-${{ env.VCPKG_COMMIT }}
         restore-keys: |
-          ${{ matrix.config.id }}-${{ hashFiles(' **/vcpkg.json') }}-${{ env.VCPKG_COMMIT }}-
-          ${{ matrix.config.id }}-${{ hashFiles(' **/vcpkg.json') }}-
           ${{ matrix.config.id }}-
 
     - name: "[Linux/macOS] Set up wxWidgets cache"


### PR DESCRIPTION
This is not needed anymore now that we are using vcpkg's binary
caching feature with GitHub Packages. This will save a lot of
space in the GitHub Actions cache, which will prevent the huge
Flatpak caches from getting evicted so frequently.

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [N/A] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>