### PR TITLE
[POC] Decide default theme on Windows based on the system theme

### DIFF
--- a/src/Theme.h
+++ b/src/Theme.h
@@ -167,6 +167,8 @@ public:
 public:
    ~Theme(void);
 public:
+   int ChooseDefaultTheme();
+   int CheckWindowsAppTheme();
    void EnsureInitialised() override;
    void RegisterImages();
    void RegisterColours();


### PR DESCRIPTION
wxWidgets provides an easy way to read registry values, apparently.
Instead of forcing the user to switch their theme so that it corresponds
to the system theme, it'd be a better idea to just do that for them.

What this change does not do: If the user changes the system theme after
Tenacity is initially configured, the theme won't change.

<details>
<summary>Additional Notes / Feedback Needed</summary>

- The change has been submitted on a branch so that other contributors with commit access can freely work on this. Some elements really make dark mode look ugly on Windows, so it may be worth pouring in some additional effort on this.
- The change was also authored with a potential expansion to GTK/Qt platforms in mind.
- The change was tested on a Windows 10 machine that had dark mode enabled for applications. Works as intended.
- I prepared a Visual Studio 2022 environment in a virtual machine and developed from it in order to get this to work. It was painful and took me several hours, but I hope it's worth it.

### Feedback Needed

This probably marks the "first substantial" patch I've sent in that concerns the code, so please bear with me, I'm trying my best.

- Although I used the `Theme` class just to get things working, I really doubt that using it and exposing it everywhere is a good thing and sensible thing to do design-wise. I don't have any better alternatives in mind (other than creating a new class) and need some further feedback.
- I am not sure if my preprocessor hacks are actually normal or super cursed.
- Should we just put the Windows-specific stuff in a separate source file or something?
- Is me initializing the booleans in the header file super cursed?
- I used `#ifdef _WIN32` instead of `#if defined(_WIN32)` like in other places. It made more sense syntax-wise, especially because I am not using a second condition over there. Need confirmation that this is okay.
- The header defines functions that are never initialized in other platforms other than Win32. What now?

</details>

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

</details>