### PR TITLE
FileDialog: move to tenacity namespace

### DIFF
--- a/src/widgets/FileDialog/FileDialog.cpp
+++ b/src/widgets/FileDialog/FileDialog.cpp
@@ -84,7 +84,7 @@ wxString FileSelector(const wxString& title,
     else if ( !filter.empty() )
         filter2 = filter;
 
-    FileDialog fileDialog(parent, title, defaultDir,
+    tenacity::FileDialog fileDialog(parent, title, defaultDir,
                             defaultFileName, filter2,
                             flags, wxPoint(x, y));
 
@@ -133,7 +133,7 @@ wxString FileSelectorEx(const wxString& title,
                         int             y)
 
 {
-    FileDialog fileDialog(parent,
+    tenacity::FileDialog fileDialog(parent,
                             title,
                             defaultDir,
                             defaultFileName,

--- a/src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
+++ b/src/widgets/FileDialog/gtk/FileDialogPrivate.cpp
@@ -241,6 +241,8 @@ void FileDialog::AddChildGTK(wxWindowGTK* child)
 // FileDialog
 //-----------------------------------------------------------------------------
 
+namespace tenacity {
+
 IMPLEMENT_DYNAMIC_CLASS(FileDialog,FileDialogBase)
 
 BEGIN_EVENT_TABLE(FileDialog,FileDialogBase)
@@ -660,3 +662,4 @@ void FileDialog::GTKFilterChanged()
     GetEventHandler()->ProcessEvent(event);
 }
 
+} // namespace tenacity

--- a/src/widgets/FileDialog/gtk/FileDialogPrivate.h
+++ b/src/widgets/FileDialog/gtk/FileDialogPrivate.h
@@ -19,6 +19,8 @@
 // FileDialog
 //-------------------------------------------------------------------------
 
+namespace tenacity {
+
 class WXDLLIMPEXP_CORE FileDialog: public FileDialogBase
 {
 public:
@@ -87,5 +89,7 @@ private:
     DECLARE_DYNAMIC_CLASS(FileDialog)
     DECLARE_EVENT_TABLE()
 };
+
+} // namespace tenacity
 
 #endif

--- a/src/widgets/FileDialog/mac/FileDialogPrivate.h
+++ b/src/widgets/FileDialog/mac/FileDialogPrivate.h
@@ -22,6 +22,8 @@ class wxChoice;
 // wxFileDialog
 //-------------------------------------------------------------------------
 
+namespace tenacity {
+
 class TENACITY_DLL_API FileDialog: public FileDialogBase
 {
 DECLARE_DYNAMIC_CLASS(FileDialog)
@@ -103,5 +105,7 @@ private:
     // Common part of all ctors.
     void Init();
 };
+
+} // namespace tenacity
 
 #endif

--- a/src/widgets/FileDialog/mac/FileDialogPrivate.mm
+++ b/src/widgets/FileDialog/mac/FileDialogPrivate.mm
@@ -44,11 +44,11 @@
 
 @interface OSPanelDelegate : NSObject <NSOpenSavePanelDelegate>
 {
-    FileDialog* _dialog;
+    tenacity::FileDialog* _dialog;
 }
 
-- (FileDialog*) fileDialog;
-- (void) setFileDialog:(FileDialog*) dialog;
+- (tenacity::FileDialog*) fileDialog;
+- (void) setFileDialog:(tenacity::FileDialog*) dialog;
 
 - (void)panel:(id)sender didChangeToDirectoryURL:(NSURL *)url;
 - (void)panelSelectionDidChange:(id)sender;
@@ -73,12 +73,12 @@
     return self;
 }
 
-- (FileDialog*) fileDialog
+- (tenacity::FileDialog*) fileDialog
 {
     return _dialog;
 }
 
-- (void) setFileDialog:(FileDialog*) dialog
+- (void) setFileDialog:(tenacity::FileDialog*) dialog
 {
     _dialog = dialog;
 }
@@ -106,6 +106,8 @@
 }
 
 @end
+
+namespace tenacity {
 
 wxIMPLEMENT_CLASS(FileDialog, FileDialogBase)
 
@@ -719,3 +721,4 @@ void FileDialog::SetFileExtension(const wxString& extension)
     [sPanel setAllowedFileTypes:types];
 }
 
+} // namespace tenacity

--- a/src/widgets/FileDialog/win/FileDialogPrivate.cpp
+++ b/src/widgets/FileDialog/win/FileDialogPrivate.cpp
@@ -78,6 +78,8 @@ static wxRect gs_rectDialog(0, 0, 428, 266);
 // implementation
 // ============================================================================
 
+namespace tenacity {
+
 IMPLEMENT_CLASS(FileDialog, wxFileDialogBase)
 
 // ----------------------------------------------------------------------------
@@ -1222,3 +1224,5 @@ bool FileDialog::Disabler::IsChild(const wxDialog *dialog) const
 
    return false;
 }
+
+} // namespace tenacity

--- a/src/widgets/wxPanelWrapper.h
+++ b/src/widgets/wxPanelWrapper.h
@@ -161,7 +161,7 @@ public:
 #include "../FileNames.h" // for FileTypes
 
 class TENACITY_DLL_API FileDialogWrapper
-   : public wxTabTraversalWrapper<FileDialog>
+   : public wxTabTraversalWrapper<tenacity::FileDialog>
 {
 public:
    FileDialogWrapper() {}
@@ -178,7 +178,7 @@ public:
       const wxSize& sz = wxDefaultSize,
       // Important:  default window name localizes!
       const TranslatableString& name = XO("File Dialog"))
-   : wxTabTraversalWrapper<FileDialog>(
+   : wxTabTraversalWrapper<tenacity::FileDialog>(
       parent, message.Translation(), defaultDir, defaultFile,
       FileNames::FormatWildcard( fileTypes ),
       style, pos, sz, name.Translation() )
@@ -197,7 +197,7 @@ public:
       // Important:  default window name localizes!
       const TranslatableString& name = XO("File Dialog"))
    {
-      wxTabTraversalWrapper<FileDialog>::Create(
+      wxTabTraversalWrapper<tenacity::FileDialog>::Create(
          parent, message.Translation(), defaultDir, defaultFile,
          FileNames::FormatWildcard( fileTypes ),
          style, pos, sz, name.Translation()


### PR DESCRIPTION
This prevents a symbol collision with FileDialog when linking wxWidgets
statically:

```
duplicate symbol 'GetTypesFromExtension(wxString, wxArrayString&)' in:
    src/CMakeFiles/Tenacity.dir/widgets/FileDialog/mac/FileDialogPrivate.mm.o
    ../wxwidgets-install/lib/libwx_osx_cocoau_core-3.1.a(filedlg.mm.o)
duplicate symbol 'GetTypesFromFilter(wxString const&, wxArrayString&, wxArrayString&)' in:
    src/CMakeFiles/Tenacity.dir/widgets/FileDialog/mac/FileDialogPrivate.mm.o
    ../wxwidgets-install/lib/libwx_osx_cocoau_core-3.1.a(filedlg.mm.o)
ld: 2 duplicate symbols for architecture x86_64
```

Signed-off-by: Be <be@mixxx.org>

I'm not sure if this is a great idea because there are other issues linking wxWidgets statically. When I tried linking wxWidgets statically on macOS, Tenacity built but crashed on startup with some error about entitlements which doesn't happen when linking wxWidgets dynamically.

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>