### PR TITLE
CMake: use local vcpkg cache after nuget cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ if( VCPKG )
   set( ENV{VCPKG_DISABLE_METRICS} true )
 
   if( NOT DEFINED ENV{VCPKG_BINARY_SOURCES} )
-    set( ENV{VCPKG_BINARY_SOURCES} "clear;nuget,tenacityteam_github_auto,read;" )
+    set( ENV{VCPKG_BINARY_SOURCES} "clear;nuget,tenacityteam_github_auto,read;default" )
   endif()
 
   set( ENV{VCPKG_FEATURE_FLAGS} "-compilertracking,manifests,registries,versions" )


### PR DESCRIPTION
When there are cache misses with NuGet, the local cache should
still be used.

Signed-off-by: Be <be@mixxx.org>

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>