### PR TITLE
Fix vcpkg issues on CI

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -114,7 +114,6 @@ jobs:
     env:
 
       AUDACITY_ARCH_LABEL: ${{ matrix.config.arch }}
-      MACOSX_DEPLOYMENT_TARGET: 10.12
 
       # CMake settings
       CMAKE_BUILD_TYPE: MinSizeRel
@@ -271,7 +270,7 @@ jobs:
         git clone --recurse-submodules ${{ env.WX_GIT_URL }}
         cd wxWidgets
         git checkout ${{ env.WX_GIT_REF }}
-        cmake -S . -B cmake_build -D CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}  -D CMAKE_INSTALL_PREFIX=${{ env.WX_INSTALL_DIR }}
+        cmake -S . -B cmake_build -D CMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}  -D CMAKE_INSTALL_PREFIX=${{ env.WX_INSTALL_DIR }} -D CMAKE_OSX_DEPLOYMENT_TARGET=10.12
         cmake --build cmake_build
         cmake --install cmake_build
 

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -11,6 +11,20 @@ defaults:
   run:
     shell: bash
 
+# See https://docs.github.com/en/rest/reference/permissions-required-for-github-apps
+# for information on what these individual permissions represent/control
+permissions:
+  actions: none
+  checks:  none
+  contents: read
+  deployments: none
+  issues: none
+  packages: read
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: read
+
 jobs:
 
   skip_test:
@@ -18,16 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
-      checks: read
-      contents: read
-      deployments: read
-      issues: read
-      discussions: read
-      packages: read
-      pull-requests: read
-      repository-projects: read
-      security-events: read
-      statuses: read
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -46,6 +50,8 @@ jobs:
     if: ${{ needs.skip_test.outputs.should_skip != 'true' }}
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -198,11 +204,7 @@ jobs:
         rm ./nuget.config
         nuget sources add -Name tenacityteam_github_auto -Source https://nuget.pkg.github.com/tenacityteam/index.json -Username tenacityteam -Password ${{ secrets.GITHUB_TOKEN }} -StorePasswordInClearText -ForceEnglishOutput -NonInteractive
         nuget setapikey ${{ secrets.GITHUB_TOKEN }} -Source tenacityteam_github_auto -ForceEnglishOutput -NonInteractive
-        if [[ ${{ github.event_name }} == 'push' ]]; then
-          echo "VCPKG_BINARY_SOURCES=clear;nuget,tenacityteam_github_auto,readwrite;" >> ${GITHUB_ENV}
-        else
-          echo "VCPKG_BINARY_SOURCES=clear;nuget,tenacityteam_github_auto,read;" >> ${GITHUB_ENV}
-        fi
+        echo "VCPKG_BINARY_SOURCES=clear;nuget,tenacityteam_github_auto,readwrite;" >> ${GITHUB_ENV}
 
     - name: "[Linux] Install dependencies"
       if: runner.os == 'Linux'

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -247,18 +247,12 @@ jobs:
         iwr -useb get.scoop.sh | iex
         scoop install sccache
 
-    # Cache the vcpkg cache and the vcpkg executable to avoid bootstrapping each time
-    - name: Setup vcpkg cache
+    # Cache the vcpkg executable to avoid bootstrapping each time
+    - name: "Setup vcpkg executable cache"
       uses: actions/cache@v2
       with:
-        path: |
-          ${{ github.workspace }}/vcpkg/vcpkg${{ env.EXE_SUFFIX }}
-          ${{ env.VCPKG_CACHE_PATH }}
-        key: ${{ matrix.config.id }}-${{ hashFiles('**/vcpkg.json') }}-${{ env.VCPKG_COMMIT }}-${{ github.run_number }}
-        restore-keys: |
-          ${{ matrix.config.id }}-${{ hashFiles(' **/vcpkg.json') }}-${{ env.VCPKG_COMMIT }}-
-          ${{ matrix.config.id }}-${{ hashFiles(' **/vcpkg.json') }}-
-          ${{ matrix.config.id }}-
+        path: ${{ github.workspace }}/vcpkg/vcpkg${{ env.EXE_SUFFIX }}
+        key: ${{ matrix.config.id }}-${{ env.VCPKG_COMMIT }}
 
     - name: "[Linux/macOS] Set up wxWidgets cache"
       uses: actions/cache@v2
@@ -329,5 +323,7 @@ jobs:
       if: always()
       with:
         name: vcpkg-logs-${{ runner.os }}
-        path: ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
+        path: |
+          ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
+          ${{ github.workspace }}/build/vcpkg-bootstrap.log
         if-no-files-found: ignore

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -322,7 +322,7 @@ jobs:
       uses: actions/upload-artifact@v2
       if: always()
       with:
-        name: vcpkg-logs-${{ runner.os }}
+        name: vcpkg-logs-${{ matrix.config.id }}
         path: |
           ${{ github.workspace }}/vcpkg/buildtrees/**/*.log
           ${{ github.workspace }}/build/vcpkg-bootstrap.log


### PR DESCRIPTION
Nuget package writing was not working correctly due to permissions misconfiguration
vcpkg was broken on macOS 11 due to misconfiguration
vcpkg logs were not being uploaded for each CI run because the cache key was not properly unique
The vcpkg submodule was updated
Change vcpkg caching to only cache the executable

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>