### PR TITLE
CMake: Disable VST (GTK) when gdk-x11-3.0 isn't found [wayland]

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -340,5 +340,5 @@ has outdated libraries that do not build with Tenacity.
   * **VAMP** (ON|OFF): VAMP plugin hosting support. Requires VAMP host SDK.
   * **LV2** (ON|OFF): LV2 plugin hosting support. Requires LV2, lilv, and
     suil libraries.
-  * **VST2** (ON|OFF): VST2 plugin hosting support. No libraries are required.
-    ON by default.
+  * **VST2** (ON|OFF): VST2 plugin hosting support. Requires GTK with X11
+    support on non-Apple/Windows.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -798,6 +798,13 @@ endif()
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
   find_package( GLIB REQUIRED )
   find_package( GTK 3.0 REQUIRED )
+  pkg_check_modules(GDK3_X11 gdk-x11-3.0)
+endif()
+
+if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
+  cmake_dependent_option( USE_VST "Use VST2 plug-in support [ON, OFF]" ON "GDK3_X11_FOUND" OFF)
+else()
+  cmd_option( USE_VST "Use VST2 plug-in support [ON, OFF]" ON)
 endif()
 
 if( NOT WIN32 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -788,13 +788,6 @@ else()
   message( STATUS "LV2 plugin hosting disabled. Requires LV2, lilv, and suil libraries." )
 endif()
 
-option( VST2 "VST2 plugin host support" ON )
-if( VST2 )
-  message( STATUS "VST2 plugin host support enabled." )
-else()
-  message( STATUS "VST2 plugin host support disabled." )
-endif()
-
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
   find_package( GLIB REQUIRED )
   find_package( GTK 3.0 REQUIRED )
@@ -802,10 +795,11 @@ if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
 endif()
 
 if( NOT CMAKE_SYSTEM_NAME MATCHES "Darwin|Windows" )
-  cmake_dependent_option( USE_VST "Use VST2 plug-in support [ON, OFF]" ON "GDK3_X11_FOUND" OFF)
+  cmake_dependent_option( VST2 "Use VST2 plug-in support [ON, OFF]" ON "GDK3_X11_FOUND" OFF)
 else()
-  cmd_option( USE_VST "Use VST2 plug-in support [ON, OFF]" ON)
+  option( VST2 "Use VST2 plug-in support" ON)
 endif()
+set(USE_VST ${VST2} CACHE INTERNAL "")
 
 if( NOT WIN32 )
   # wxWidgets 3.1 can be explicitly selected if both 3.0 and 3.1 are installed by setting

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,10 +57,6 @@ endif()
 cmd_option( use_ladspa "Use LADSPA plug-in support [ON, OFF]" ON )
 set( USE_LADSPA ${use_ladspa} CACHE INTERNAL "" )
 
-# Handle VST option
-cmd_option( use_vst "Use VST2 plug-in support [ON, OFF]" ON )
-set( USE_VST ${use_vst} CACHE INTERNAL "" )
-
 # ~~~
 # General source files
 # ~~~


### PR DESCRIPTION
The VST plugin done via GTK for non-apple & non-windows pulls <gdk/gdkx.h>,
which is specific to X11 and thus isn't available in a pure-wayland system.

This disables it automatically.

Closes: https://github.com/tenacityteam/tenacity/issues/614

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>