### PR TITLE
Make skipped CI builds have name

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -44,7 +44,7 @@ jobs:
   build:
     needs: skip_test
     if: ${{ needs.skip_test.outputs.should_skip != 'true' }}
-    name: ${{ matrix.config.name }}
+    name: ${{ matrix.config.name || "Build Skipped" }}
     runs-on: ${{ matrix.config.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Prevent skipped builds from showing CI expression as a name when skipped

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>