### PR TITLE
Fix clang compiler build info

### DIFF
--- a/src/BuildInfo.h
+++ b/src/BuildInfo.h
@@ -81,7 +81,7 @@ public:
               #define __clang_minor__ 0
               #define __clang_patchlevel__ 0
             #endif
-            return wxString::Format( wxT("clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
+            return wxString::Format( wxT("Clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
 
           case BuildInfo::CompilerType::AppleClang:
             #if !defined(__clang_major__) || !defined (__clang_minor__) || !defined(__clang_patchlevel__)
@@ -90,7 +90,7 @@ public:
               #define __clang_minor__ 0
               #define __clang_patchlevel__ 0
             #endif
-            return wxString::Format( wxT("Apple clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
+            return wxString::Format( wxT("Apple Clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
 
           case BuildInfo::CompilerType::Unknown:
           default:

--- a/src/BuildInfo.h
+++ b/src/BuildInfo.h
@@ -26,17 +26,19 @@
 class BuildInfo {
 
 public:
-      enum class CompilerType { MSVC, MinGW, GCC, Clang, Unknown };
+      enum class CompilerType { MSVC, MinGW, GCC, Clang, AppleClang, Unknown };
 
       static constexpr auto CurrentBuildCompiler =
         #if defined(_MSC_FULL_VER)
               CompilerType::MSVC;
         #elif defined(__GNUC_PATCHLEVEL__) && defined(__MINGW32__)
               CompilerType::MinGW;
-        #elif defined(__GNUC_PATCHLEVEL__)
+        #elif defined(__GNUC_PATCHLEVEL__) && !defined(__llvm__) && !defined(__clang__)
               CompilerType::GCC;
-        #elif defined(__clang_version__)
+        #elif defined(__clang_version__) && !defined(__apple_build_version__)
               CompilerType::Clang;
+        #elif defined(__clang_version__) && defined(__apple_build_version__)
+              CompilerType::AppleClang;
         #else
               CompilerType::Unknown;
         #endif
@@ -80,6 +82,15 @@ public:
               #define __clang_patchlevel__ 0
             #endif
             return wxString::Format( wxT("clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
+
+          case BuildInfo::CompilerType::AppleClang:
+            #if !defined(__clang_major__) || !defined (__clang_minor__) || !defined(__clang_patchlevel__)
+              // This should be unreachable, but it makes the compiler realize that they will always be defined
+              #define __clang_major__ 0
+              #define __clang_minor__ 0
+              #define __clang_patchlevel__ 0
+            #endif
+            return wxString::Format( wxT("Apple clang %s"), CUSTOM_wxMAKE_VERSION_DOT_STRING_T(__clang_major__, __clang_minor__, __clang_patchlevel__));
 
           case BuildInfo::CompilerType::Unknown:
           default:


### PR DESCRIPTION
Make GCC/clang differentiation more accurate
Add "Apple clang" detection

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/622

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>