### PR TITLE
Tenacity renaming in macOS manifest

### DIFF
--- a/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
+++ b/cmake-proxies/cmake-modules/MacOSXBundleInfo.plist.in
@@ -206,7 +206,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Wrapper</string>
 	<key>CFBundleGetInfoString</key>
-	<string>Audacity version ${GIT_DESCRIBE}</string>
+	<string>Tenacity version ${GIT_DESCRIBE}</string>
 	<key>CFBundleIconFile</key>
 	<string>Tenacity.icns</string>
 	<key>CFBundleIdentifier</key>
@@ -216,7 +216,7 @@
 	<key>CFBundleLongVersionString</key>
 	<string>Version ${GIT_DESCRIBE}</string>
 	<key>CFBundleName</key>
-	<string>Audacity</string>
+	<string>Tenacity</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
@@ -232,9 +232,9 @@
    <key>NSRequiresAquaSystemAppearance</key>
    <true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Audacity version ${GIT_DESCRIBE}</string>
+	<string>Tenacity version ${GIT_DESCRIBE}</string>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Audacity requires access to the microphone only if you intend to record from it.</string>
+	<string>Tenacity requires access to the microphone only if you intend to record from it.</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 </dict>


### PR DESCRIPTION
Removes all mentions of Audacity from the MacOS Manifest file

Resolves: #618 

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>