### PR TITLE
Disable build skipping action temporarily

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -36,7 +36,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@f75dd6564bb646f95277dc8c3b80612e46a4a1ea
         with:
           paths: '[]'
           paths_ignore: '["**/**.md", "**/**.dox2", "**/**.dox", "**/**.dox.in", "**/LICENSE.txt", "/.builds/**", "/.github/ISSUE_TEMPLATE/**", "/.github/funding.yml", "/.vscode/**"]'

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -27,27 +27,27 @@ permissions:
 
 jobs:
 
-  skip_test:
-    name: "CI Build Skipping Logic"
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    outputs:
-      should_skip: ${{ steps.skip_check.outputs.should_skip }}
-    steps:
-      - id: skip_check
-        uses: fkirc/skip-duplicate-actions@f75dd6564bb646f95277dc8c3b80612e46a4a1ea
-        with:
-          paths: '[]'
-          paths_ignore: '["**/**.md", "**/**.dox2", "**/**.dox", "**/**.dox.in", "**/LICENSE.txt", "/.builds/**", "/.github/ISSUE_TEMPLATE/**", "/.github/funding.yml", "/.vscode/**"]'
-          do_not_skip: '["workflow_dispatch", "schedule"]'
-          cancel_others: 'true'
-          skip_after_successful_duplicate: 'true'
-          concurrent_skipping: 'same_content_newer'
+#  skip_test:
+#    name: "CI Build Skipping Logic"
+#    runs-on: ubuntu-latest
+#    permissions:
+#      actions: write
+#    outputs:
+#      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+#    steps:
+#      - id: skip_check
+#        uses: fkirc/skip-duplicate-actions@f75dd6564bb646f95277dc8c3b80612e46a4a1ea
+#        with:
+#          paths: '[]'
+#          paths_ignore: '["**/**.md", "**/**.dox2", "**/**.dox", "**/**.dox.in", "**/LICENSE.txt", "/.builds/**", "/.github/ISSUE_TEMPLATE/**", "/.github/funding.yml", "/.vscode/**"]'
+#          do_not_skip: '["workflow_dispatch", "schedule"]'
+#          cancel_others: 'true'
+#          skip_after_successful_duplicate: 'true'
+#          concurrent_skipping: 'same_content_newer'
 
   build:
-    needs: skip_test
-    if: ${{ needs.skip_test.outputs.should_skip != 'true' }}
+#    needs: skip_test
+#    if: ${{ needs.skip_test.outputs.should_skip != 'true' }}
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
     permissions:


### PR DESCRIPTION
Use SHA of 3.4.1 version of fkirc/skip-duplicate-actions
Disable skip build job while we wait for the action to be updated to accommodate the consequences of a sensitive material removal request on a PR. 

This PR was merged without review due to scope of the damage to the build process (all CI runs which invoke the fkirc/skip-duplicate-actions action on this repository would continue to fail so long as the problem persists) and due to the likelihood that the fix would potentially take longer than a few hours (since it relies on 3rd party actions).

Signed-off-by: Emily Mabrey <emabrey@tenacityaudio.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>