### PR TITLE
Make wxWidgets version in About dialog more visible

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -179,6 +179,7 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
     AddBuildInfoRow(&informationStr, XO("Version:"), BuildInfo::getRevisionIdentifier());
     AddBuildInfoRow(&informationStr, XO("Build type:"), BuildInfo::getBuildType());
     AddBuildInfoRow(&informationStr, XO("Compiler:"), BuildInfo::getCompilerVersionString());
+    AddBuildInfoRow(&informationStr, XO("wxWidgets:"), BuildInfo::getWxWidgetsVersion());
 
     // Install prefix
 #ifdef __WXGTK__
@@ -201,7 +202,6 @@ void AboutDialog::CreateInformationTab(ShuttleGui& AboutDialogGUI) {
     informationStr
         << wxT("<table>");   // start table of file formats supported
 
-    AddBuildInfoRow(&informationStr, wxT("wxWidgets"), XO("Cross-platform GUI library"), Verbatim(wxVERSION_NUM_DOT_STRING_T));
     AddBuildInfoRow(&informationStr, wxT("PortAudio"), XO("Audio playback and recording"), Verbatim(wxT("v19")));
     AddBuildInfoRow(&informationStr, wxT("libsoxr"), XO("Sample rate conversion"), enabled);
 

--- a/src/BuildInfo.h
+++ b/src/BuildInfo.h
@@ -139,5 +139,15 @@ public:
 
             return o.GetString();
         }
+
+        static const wxString getWxWidgetsVersion() {
+            wxPlatformInfo info = wxPlatformInfo::Get();
+
+            return wxString::Format("v%s (%s v%d.%d)",
+                        wxVERSION_NUM_DOT_STRING_T,
+                        info.GetPortIdShortName(),
+                        info.GetToolkitMajorVersion(),
+                        info.GetToolkitMinorVersion());
+        }
 };
 #endif


### PR DESCRIPTION
Signed-off-by: Leon Marz <main@lmarz.org>

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: #612

The Build Information in the About dialog already contained the wxWidgets version in the file format section. This commit moves it more to the top to be more visible, especially for inexperienced users who write their first bug report.

Before:
![20210917_17h32m04s_grim](https://user-images.githubusercontent.com/37630820/133816029-87945e6b-af48-4bce-aec3-b960cf553507.png)
After:
![20210917_22h44m33s_grim](https://user-images.githubusercontent.com/37630820/133851579-c5682cd3-0fb0-4e46-b230-e78d6c3291ad.png)

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>