### PR TITLE
[POC] Make Git a mandatory build dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,88 @@ else()
   set( AUDACITY_NAME "tenacity")
 endif()
 
+if( WIN32 OR APPLE )
+  option( VCPKG "Use vcpkg for dependencies" ON )
+else()
+  option( VCPKG "Use vcpkg for dependencies" OFF )
+endif()
+
+# Make sure that we have actually attempted to find Git
 if(NOT GIT_FOUND)
   find_package( Git )
+endif()
+
+# Oops, our attempt failed
+if(NOT GIT_FOUND)
+  if( VCPKG )
+    message( FATAL_ERROR "Git NOT found."
+      "Please install Git from https://git-scm.com/ or your package manager."
+      "We use Git to detect the current version of Tenacity, as well as for"
+      "downloading a couple of dependencies that Tenacity depends on.")
+  else()
+    message( FATAL_ERROR "Git NOT found."
+      "Please install Git from https://git-scm.com/ or your package manager."
+      "We use Git to detect the current version of Tenacity.")
+  endif()
+endif()
+
+# ~~~~~~~
+#  Vcpkg
+# ~~~~~~~
+
+if( VCPKG )
+  set( ENV{VCPKG_DISABLE_METRICS} true )
+
+  if( NOT DEFINED ENV{VCPKG_BINARY_SOURCES} )
+    set( ENV{VCPKG_BINARY_SOURCES} "clear;nuget,tenacityteam_github_auto,read;" )
+  endif()
+
+  set( ENV{VCPKG_FEATURE_FLAGS} "-compilertracking,manifests,registries,versions" )
+
+  if( VCPKG_ROOT )
+    message( STATUS "Using dependencies from vcpkg repository at ${VCPKG_ROOT}" )
+
+    if( NOT EXISTS "${VCPKG_ROOT}/bootstrap-vcpkg.sh" )
+      message( FATAL_ERROR "${VCPKG_ROOT} is not a vcpkg Git repository." )
+    endif()
+
+  else()
+    message( STATUS "Using dependencies from vcpkg Git submodule" )
+    set( VCPKG_ROOT "${CMAKE_SOURCE_DIR}/vcpkg" )
+
+    if( NOT EXISTS "${VCPKG_ROOT}/bootstrap-vcpkg.sh" )
+
+      message( STATUS "Initializing vcpkg Git submodule" )
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} submodule init
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      )
+      execute_process(
+        COMMAND ${GIT_EXECUTABLE} submodule update
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+      )
+    endif()
+  endif()
+
+  if( NOT DEFINED VCPKG_OVERLAY_PORTS )
+    set( VCPKG_OVERLAY_PORTS "${VCPKG_ROOT}/overlay/ports" )
+  endif()
+
+  if( NOT DEFINED VCPKG_OVERLAY_TRIPLETS )
+    set( VCPKG_OVERLAY_TRIPLETS "${VCPKG_ROOT}/overlay/triplets" )
+  endif()
+
+  if( NOT DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET )
+    if( APPLE )
+      set( VCPKG_TARGET_TRIPLET "x64-osx-10.12min" )
+    endif()
+  elseif( DEFINED ENV{VCPKG_DEFAULT_TRIPLET} )
+    set( VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" )
+  endif()
+
+  set( CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" )
+else()
+  message( STATUS "Searching for dependencies from system, not using vcpkg." )
 endif()
 
 # ~~~~~~~~~
@@ -89,80 +169,6 @@ if( GIT_FOUND )
     list( GET git_output 1 AUDACITY_RELEASE )
     list( GET git_output 2 AUDACITY_REVISION )
   endif()
-endif()
-
-# ~~~~~~~
-#  Vcpkg
-# ~~~~~~~
-
-if( WIN32 OR APPLE )
-  option( VCPKG "Use vcpkg for dependencies" ON )
-else()
-  option( VCPKG "Use vcpkg for dependencies" OFF )
-endif()
-
-if( VCPKG )
-  set( ENV{VCPKG_DISABLE_METRICS} true )
-
-  if( NOT DEFINED ENV{VCPKG_BINARY_SOURCES} )
-    set( ENV{VCPKG_BINARY_SOURCES} "clear;nuget,tenacityteam_github_auto,read;" )
-  endif()
-
-  set( ENV{VCPKG_FEATURE_FLAGS} "-compilertracking,manifests,registries,versions" )
-
-  if( VCPKG_ROOT )
-    message( STATUS "Using dependencies from vcpkg repository at ${VCPKG_ROOT}" )
-
-    if( NOT EXISTS "${VCPKG_ROOT}/bootstrap-vcpkg.sh" )
-      message( FATAL_ERROR "${VCPKG_ROOT} is not a vcpkg Git repository." )
-    endif()
-
-  else()
-    message( STATUS "Using dependencies from vcpkg Git submodule" )
-    set( VCPKG_ROOT "${CMAKE_SOURCE_DIR}/vcpkg" )
-
-    if( NOT EXISTS "${VCPKG_ROOT}/bootstrap-vcpkg.sh" )
-
-      # Make sure we have actually attempted to find Git
-      if( NOT GIT_FOUND )
-        find_package( Git )
-      endif()
-
-      if( GIT_FOUND )
-        message( STATUS "Initializing vcpkg Git submodule" )
-        execute_process(
-          COMMAND ${GIT_EXECUTABLE} submodule init
-          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        )
-        execute_process(
-          COMMAND ${GIT_EXECUTABLE} submodule update
-          WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-        )
-      else()
-        message( FATAL_ERROR "Unable to initialize vcpkg Git submodule because CMake was unable to find a git installation" )
-      endif()
-    endif()
-  endif()
-
-  if( NOT DEFINED VCPKG_OVERLAY_PORTS )
-    set( VCPKG_OVERLAY_PORTS "${VCPKG_ROOT}/overlay/ports" )
-  endif()
-
-  if( NOT DEFINED VCPKG_OVERLAY_TRIPLETS )
-    set( VCPKG_OVERLAY_TRIPLETS "${VCPKG_ROOT}/overlay/triplets" )
-  endif()
-
-  if( NOT DEFINED ENV{VCPKG_DEFAULT_TRIPLET} AND NOT DEFINED VCPKG_TARGET_TRIPLET )
-    if( APPLE )
-      set( VCPKG_TARGET_TRIPLET "x64-osx-10.12min" )
-    endif()
-  elseif( DEFINED ENV{VCPKG_DEFAULT_TRIPLET} )
-    set( VCPKG_TARGET_TRIPLET "$ENV{VCPKG_DEFAULT_TRIPLET}" )
-  endif()
-
-  set( CMAKE_TOOLCHAIN_FILE "${VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake" )
-else()
-  message( STATUS "Searching for dependencies from system, not using vcpkg." )
 endif()
 
 # ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We are planning to use Git to detect the current version of Tenacity, instead
of depending on a hardcoded variable, as that is an approach that is far from
foolproof. We already depended on it for Windows and macOS builds, as vcpkg
uses Git to fetch a couple of dependencies. The vcpkg has also been
appropriately adjusted and cleaned up.

It may seem a bit excessive, but the operating systems we support all have
a version of Git that is available and it is not a runtime dependency. We
assume that people who can gain access to the source code can also install
a copy of Git. If we actually come across some sort of an extreme edge case
where this is not true, we can set the versions to `9999` just like in
`win/tenacity.rc`, in order to ensure portability, at a later point in time.

This change is a measure that will ensure that we are going to avoid mistakes
that we will not be able to undo later.

For more context: See this [comments section](https://github.com/tenacityteam/tenacity/commit/dbe4b564d45a921b136b8b289a0769649b8035b0)

<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

</details>

P.S. I fully understand that this isn't how other projects do it and how this proposal can be very controversial. We should also consider the goal to offer reproducible builds and whether this change will compromise it. Feel free to throw it out if it's not needed.