### PR TITLE
Fix version detection in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ set( GIT_DESCRIBE "unknown" )
 
 if( GIT_FOUND )
   execute_process(
-    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=7
+    COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=7 --match="*.*.*"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE GIT_DESCRIBE
     OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET


### PR DESCRIPTION
Resolves: *#640*

The CMake build uses git describe to retrieve version information from
the latest git tag. However, if there is a tag like "alpha" which does
not match the expected pattern "Audacity-X.X.X", CMake cannot parse the
returned string from git and fails.

As fix, pass the argument "--match 'Audacity-*'" to the "git describe"
call so that it looks for the latest tag matching the expected pattern.
This should also fix the sr.ht CI builds.

<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*