### PR TITLE
Add missing include in AColor.cpp

### DIFF
--- a/src/AColor.cpp
+++ b/src/AColor.cpp
@@ -22,6 +22,7 @@ It is also a place to document colour usage policy in Audacity
 #include "AColorResources.h"
 
 
+#include <algorithm>
 #include <wx/window.h>
 #include <wx/colour.h>
 #include <wx/dc.h>


### PR DESCRIPTION
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: https://github.com/tenacityteam/tenacity/issues/662

Adds include for copy_n in AColor.cpp to fix compile issues on some systems

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>