### PR TITLE
Update SoundTouch in Flatpak manifest

### DIFF
--- a/packaging/flatpak/org.tenacity.Tenacity.json
+++ b/packaging/flatpak/org.tenacity.Tenacity.json
@@ -162,9 +162,9 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://gitlab.com/soundtouch/soundtouch.git",
-          "tag": "2.3.0",
-          "commit": "c65afe49f697fcea87d9a134870c8d115d7700cc"
+          "url": "https://codeberg.org/soundtouch/soundtouch.git",
+          "tag": "2.3.1",
+          "commit": "e1f315f5358d9db5cee35a7a2886425489fcefe8"
         }
       ]
     },


### PR DESCRIPTION
SoundTouch migrated to Codeberg from GitLab recently.
This updates the SoundTouch dependency in the Flatpak manifest.

Signed-off-by: TheEvilSkeleton <theevilskeleton@riseup.net>

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [ ] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>