### PR TITLE
Precise build steps

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -207,7 +207,7 @@ If you switch between system packages and vcpkg, you may need to delete
 
 Install
 [Microsoft Visual Studio](https://visualstudio.microsoft.com/vs/community/)
-with the **Desktop development with C++** installation option.
+with the **Desktop development with C++** installation option. Microsoft's ATL/MFC components are also needed to build the application.
 
 Installing [sccache](https://github.com/mozilla/sccache) is highly recommended
 for faster builds but not required. CMake will automatically use sccache if you
@@ -291,13 +291,13 @@ cmake -G Ninja -S . -B build
 Build Tenacity:
 
 ```
-cmake --build build
+cmake --build build --config Release
 ```
 
 Run Tenacity:
 
 ```
-build/bin/Debug/tenacity
+build/bin/Release/tenacity
 ```
 
 Optionally, install Tenacity:


### PR DESCRIPTION
!. ATL/MFC components (v14.22) are not included by default in the C++ development kit, but are needed to compile the project.

2. In Windows (not checked for linux distributions), cmake will build a Debug version of the software. Since cmake will check for information marked as "Release" to install the application by default (and not Debug), I think that it is fair to explicitly tell the persons who only want to install the project to build a "Release" version of the software.

Signed-off-by: BBArikL BBArik@protonmail.com
<!--

IMPORTANT! READ

Any spam PRs will be closed.
Please make sure your PR
complies with the requirements.
-->

Resolves: *(direct link to the issue)*
Precise steps to build the project faster.
*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x]
an asterisk (*) after the entry indicates required
-->

<details>
<summary>Checklist</summary>

- [x] I have signed off my commits using `-s` or `Signed-off-by`\* (See: [Contributing § DCO](https://github.com/tenacityteam/tenacity/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
- [x] I made sure the code compiles on my machine
- [x] I made sure there are no unnecessary changes in the code\*
- [x] I made sure the title of the PR reflects the core meaning of the issue you are solving\*
- [x] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"\*

\* indicates required

</details>